### PR TITLE
Add option to delete entries

### DIFF
--- a/cmd/ssh_ms.go
+++ b/cmd/ssh_ms.go
@@ -80,6 +80,18 @@ var (
 		},
 	}
 
+	deleteCmd = &cobra.Command{
+		Use:   "delete KEY [flags]",
+		Short: "Delete a config",
+		Long:  "Delete an existing SSH configuration from Vault",
+		Example: `
+    ssh_ms delete localhost 
+		`,
+		Run: func(cmd *cobra.Command, args []string) {
+			deleteSecret(*getVaultClient(), args[0])
+		},
+	}
+
 	listCmd = &cobra.Command{
 		Use:   "list [flags]",
 		Short: "List available connections",
@@ -349,6 +361,13 @@ func connect(vc api.Client, env ssh.UserEnv, args []string) {
 	}
 }
 
+// deleteSecret in Vault
+// vc : Vault client
+// key : secret to remove
+func deleteSecret(vc api.Client, key string) bool {
+	return vault.DeleteSecret(vc, fmt.Sprintf("secret/ssh_ms/%s", key))
+}
+
 // listSecrets in Vault
 // vc : Vault client
 func listSecrets(vc api.Client) bool {
@@ -490,6 +509,7 @@ func printVersion() {
 func Execute() {
 	rootCmd.AddCommand(
 		connectCmd,
+		deleteCmd,
 		listCmd,
 		purgeCmd,
 		showCmd,

--- a/vault/helper.go
+++ b/vault/helper.go
@@ -12,6 +12,16 @@ type UserEnv struct {
 	Simulate    bool
 }
 
+// DeleteSecret removes a secret from Vault
+func DeleteSecret(c api.Client, key string) bool {
+	if _, err := c.Logical().Delete(key); err != nil {
+		log.Fatal(err)
+		return false
+	}
+
+	return true
+}
+
 // ListSecrets reads the list of secrets/data under a path in Vault
 // c : Vault client
 // path : path to secret/data in Vault


### PR DESCRIPTION
Users may now remove entries without the need for direct use of the Vault client:
```sh
ssh_ms delete mysecret
```

Resolves #3 