### PR TITLE
Refactor vault.WriteSecret

### DIFF
--- a/cmd/ssh_ms.go
+++ b/cmd/ssh_ms.go
@@ -434,7 +434,7 @@ func writeSecret(vc api.Client, key string, args []string) bool {
 	}
 
 	if !flags.Simulate {
-		status = vault.WriteSecret(vc, key, secret)
+		status = vault.WriteSecret(vc, fmt.Sprintf("secret/ssh_ms/%s", key), secret)
 	} else {
 		log.Println(" - secret would be: ", secret)
 	}

--- a/vault/helper.go
+++ b/vault/helper.go
@@ -45,8 +45,11 @@ func ReadSecret(c api.Client, key string) *api.Secret {
 }
 
 // WriteSecret adds a secret to Vault
+// c : Vault client
+// key : the key for the secret
+// data : config for use when writing data
 func WriteSecret(c api.Client, key string, data map[string]interface{}) bool {
-	if _, err := c.Logical().Write("secret/ssh_ms/"+key, data); err != nil {
+	if _, err := c.Logical().Write(key, data); err != nil {
 		log.Fatal(err)
 		return false
 	}


### PR DESCRIPTION
The other helpers accept a preformatted path instead of just the key, so updating WriteSecret to match the rest