### PR TITLE
Enable comments to be applied to a rendered config

### DIFF
--- a/cmd/ssh_ms.go
+++ b/cmd/ssh_ms.go
@@ -31,7 +31,7 @@ const EnvBasePath = "HOME"
 
 type cmdFlags struct {
 	Expert, List, Purge, StoredToken, Simulate, Verbose, Version bool
-	Addr, Show, StoragePath, Token, User, Write                  string
+	Addr, Comment, Show, StoragePath, Token, User, Write         string
 }
 
 type secretData map[string]interface{}
@@ -414,6 +414,9 @@ func showSecret(vc *api.Client, key string) bool {
 	sshArgs := sshClient.BuildConnection(secret.Data, key)
 	config := rewriteEmpty(rewriteUsername(sshClient.Cache))
 
+	if secret.Data["ConfigComment"] != "" {
+		fmt.Println("#", secret.Data["ConfigComment"])
+	}
 	fmt.Print(config)
 
 	if flags.Verbose {
@@ -435,6 +438,8 @@ func writeSecret(vc *api.Client, key string, args []string) bool {
 		s := strings.Split(args[i], "=")
 		secret[s[0]] = s[1]
 	}
+
+	secret["ConfigComment"] = flags.Comment
 
 	if !flags.Simulate {
 		status = vault.WriteSecret(vc, fmt.Sprintf("secret/ssh_ms/%s", key), secret)
@@ -532,7 +537,7 @@ func Execute() {
 
 	connectCmd.Flags().BoolVarP(&flags.Expert, "expert", "e", false, "Expert-mode - pass in your SSH args")
 
-	//writeCmd.Flags().StringVarP()
+	writeCmd.Flags().StringVarP(&flags.Comment, "comment", "c", "", "Add a comment to the config")
 
 	if flags.Token == "" {
 		flags.StoredToken = true


### PR DESCRIPTION
Enable comments to be applied to a rendered config

When writing a config it is now possible to assign a comment
using the `--comment` flag. This will then render when using the
`show` command, e.g.

```sh
$ ssh_ms write testing --comment "Test Comment"
$ ssh_ms show testing

# Test Comment
Host testing
    HostName localhost 
    Port 22
    User root
    IdentityFile ~/.ssh/id_rsa
    IdentitiesOnly yes
```

Adds support for https://github.com/cezmunsta/ssh_ms/issues/1