### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,13 @@ DEFAULT_VAULT_ADDR?="https://127.0.0.1:8200"
 SSH_DEFAULT_USERNAME?="${USER}"
 SSH_MS_USERNAME?="SSH_MS_USERNAME"
 SSH_ID_FILE?="id_rsa"
+SSH_MS_SYNC_HOST?="localhost"
+SSH_MS_SYNC_PATH?="/usr/share/nginx/html/downloads/ssh_ms/"
 
 PACKAGE="github.com/cezmunsta/ssh_ms"
-LDFLAGS=-ldflags "-X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/cmd.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/cmd.EnvSSHIdentityFile=${SSH_ID_FILE} -X ${PACKAGE}/ssh.EnvSSHDefaultUsername=${SSH_DEFAULT_USERNAME} -X ${PACKAGE}/cmd.EnvVaultAddr=${DEFAULT_VAULT_ADDR}"
+LDFLAGS=-ldflags "-w -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/cmd.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/cmd.EnvSSHIdentityFile=${SSH_ID_FILE} -X ${PACKAGE}/ssh.EnvSSHDefaultUsername=${SSH_DEFAULT_USERNAME} -X ${PACKAGE}/cmd.EnvVaultAddr=${DEFAULT_VAULT_ADDR}"
 
-SYNC_HOST="localhost"
-SYNC_PATH="/usr/share/nginx/html/downloads/ssh_ms/"
-
-all: lint format binaries
+all: lint format test binaries
 
 binaries: binary-linux binary-mac
 
@@ -24,7 +23,7 @@ flags:
 	@echo -e "\"${LDFLAGS}\"" | sed 's/-ldflags /-ldflags "/; s/^"//'
 
 sync:
-	@rsync -rlpDvc --progress bin/{linux,darwin} "${SYNC_HOST}":"${SYNC_PATH}"
+	@rsync -rlpDvc --progress bin/{linux,darwin} "${SSH_MS_SYNC_HOST}":"${SSH_MS_SYNC_PATH}"
 
 binary-prep:
 	@mkdir -p ${BUILD_DIR}/${GOOS}/${GOARCH};
@@ -44,17 +43,23 @@ binary-linux: binary-prep
 build: binary-prep
 	@go build -o "${BUILD_DIR}/ssh_ms" ${LDFLAGS}
 
+test:
+	@go test "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault"
+
 lint:
-	@golint .
+	@golint ssh vault cmd
 
 format:
-	@gofmt -w .
+	@gofmt -w ssh vault cmd
 
 simplify:
-	@gofmt -s -w .
+	@gofmt -s -w ssh vault cmd
 
 vet:
-	@go vet -x .
+	@go vet "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault"
+
+fix:
+	@go tool fix -diff ssh vault cmd
 
 clean:
 	@find "${BUILD_DIR}" -type f -delete


### PR DESCRIPTION
- Allow the synchronisation host and path to be set
  from the environment during `make sync`
- Renamed sync variables to use `SSH_MS_` prefix
- Added `-w` to `ldflags` to reduce size of binaries a little
- Explicit targeting of packages when using `gofmt`, etc