### PR TITLE
Fixed lint issues

### DIFF
--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -22,6 +22,7 @@ import (
 
 type secretData map[string]interface{}
 
+// CacheExpireAfter sets the threshold for cleaning stales caches
 const CacheExpireAfter = (7 * 24) * time.Hour
 
 // listConnections from Vault

--- a/ssh/main.go
+++ b/ssh/main.go
@@ -41,6 +41,7 @@ var (
 		`-ldflags "-X github.com/cezmunsta/ssh_ms/ssh.EnvSSHDefaultUsername=xxx"`
 
 	*/
+
 	// EnvSSHDefaultUsername is used to authenticate with SSH
 	EnvSSHDefaultUsername = os.Getenv("USER")
 )


### PR DESCRIPTION
* Added comment to `cmd.CacheExpireAfter`
* Added newline to split the information comment from the variable,
  as linting would error