### PR TITLE
Partial updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ SSH_MS_SYNC_HOST?="localhost"
 SSH_MS_SYNC_PATH?="/usr/share/nginx/html/downloads/ssh_ms/"
 
 PACKAGE="github.com/cezmunsta/ssh_ms"
-LDFLAGS=-ldflags "-w -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/cmd.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/cmd.EnvSSHIdentityFile=${SSH_ID_FILE} -X ${PACKAGE}/ssh.EnvSSHDefaultUsername=${SSH_DEFAULT_USERNAME} -X ${PACKAGE}/cmd.EnvVaultAddr=${DEFAULT_VAULT_ADDR}"
+LDFLAGS=-ldflags "-w -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_DEFAULT_USERNAME} -X ${PACKAGE}/cmd.EnvVaultAddr=${DEFAULT_VAULT_ADDR}"
 
 all: lint format test binaries
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -101,6 +101,15 @@ var (
 		},
 	}
 
+	updateCmd = &cobra.Command{
+		Use:   "update CONNECTION [args]",
+		Short: "Update an existing connection to storage",
+		Long:  "TBD",
+		Run: func(cmd *cobra.Command, args []string) {
+			updateConnection(getVaultClient(), args[0], args[1:])
+		},
+	}
+
 	writeCmd = &cobra.Command{
 		Use:   "write CONNECTION [args]",
 		Short: "Add a new connection to storage",
@@ -139,6 +148,7 @@ func init() {
 		purgeCmd,
 		showCmd,
 		versionCmd,
+		updateCmd,
 		writeCmd,
 	)
 	rootCmd.PersistentFlags().StringVar(&cfg.VaultAddr, "vault-addr", os.Getenv(vaultApi.EnvVaultAddress), "Specify the Vault address")
@@ -152,6 +162,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&cfg.Simulate, "dry-run", "n", false, "Prevent certain commands without full execution")
 	rootCmd.PersistentFlags().BoolVarP(&cfg.Verbose, "verbose", "v", false, "Provide addition output")
 
+	updateCmd.Flags().StringVarP(&cfg.ConfigComment, "comment", "c", "", "Set the comment for the config entry")
 	writeCmd.Flags().StringVarP(&cfg.ConfigComment, "comment", "c", "", "Add a comment for the config entry")
 
 	log := log.GetLogger(log.GetDefaultLevel(), "")

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -162,7 +162,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&cfg.Simulate, "dry-run", "n", false, "Prevent certain commands without full execution")
 	rootCmd.PersistentFlags().BoolVarP(&cfg.Verbose, "verbose", "v", false, "Provide addition output")
 
-	updateCmd.Flags().StringVarP(&cfg.ConfigComment, "comment", "c", "", "Set the comment for the config entry")
+	updateCmd.Flags().StringVarP(&cfg.ConfigComment, "comment", "c", "", "Set thecomment for the config entry")
 	writeCmd.Flags().StringVarP(&cfg.ConfigComment, "comment", "c", "", "Add a comment for the config entry")
 
 	log := log.GetLogger(log.GetDefaultLevel(), "")

--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -22,7 +22,7 @@ import (
 
 type secretData map[string]interface{}
 
-// CacheExpireAfter sets the threshold for cleaning stales caches
+// CacheExpireAfter sets the threshold for cleaning stale caches
 const CacheExpireAfter = (7 * 24) * time.Hour
 
 // listConnections from Vault
@@ -87,8 +87,8 @@ func printConnection(vc *vaultApi.Client, key string) bool {
 
 // writeConnection creates a new entry, or updates an existing one
 func writeConnection(vc *vaultApi.Client, key string, args []string) bool {
-	log.Debugf("writeConnection %v", key)
-	conn, err := getRawConnection(vc, key)
+	log.Debugf("writeConnection: %v", key)
+	_, err := getRawConnection(vc, key)
 	secret := make(secretData)
 
 	if err != nil {
@@ -99,8 +99,7 @@ func writeConnection(vc *vaultApi.Client, key string, args []string) bool {
 		}
 	} else {
 		// Existing connection
-		log.Warning("Updating an existing connection is WIP")
-		log.Debug("writeConnection found: ", conn)
+		log.Warningf("Existing connection found for '%v', please use update instead", key)
 		return false
 	}
 
@@ -112,6 +111,41 @@ func writeConnection(vc *vaultApi.Client, key string, args []string) bool {
 	}
 
 	status, err := vaultHelper.WriteSecret(vc, fmt.Sprintf("%s/%s", SecretPath, key), secret)
+	if err != nil {
+		log.Errorf("Failed to write '%v': %v", key, err)
+		return false
+	}
+	return status
+}
+
+// updateConnection performs a partial update of an existing connection
+func updateConnection(vc *vaultApi.Client, key string, args []string) bool {
+	log.Debugf("updateConnection: %v", key)
+	conn, err := getRawConnection(vc, key)
+
+	if err != nil {
+		log.Warningf("Unable to retrieve connection '%v', please use write instead", key)
+		return false
+	}
+
+	for i := 0; i < len(args); i++ {
+		s := strings.Split(args[i], "=")
+		if len(s) != 2 {
+			log.Fatalf("Unexpected option '%v', expected XXX=YYY", args[i])
+		}
+		conn.Data[s[0]] = s[1]
+	}
+
+	if len(cfg.ConfigComment) > 0 {
+		conn.Data["ConfigComment"] = cfg.ConfigComment
+	}
+
+	if cfg.Simulate {
+		log.Infof("Simulate update of '%v'", key, conn.Data)
+		return true
+	}
+
+	status, err := vaultHelper.WriteSecret(vc, fmt.Sprintf("%s/%s", SecretPath, key), conn.Data)
 	if err != nil {
 		log.Errorf("Failed to write '%v': %v", key, err)
 		return false

--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -27,6 +27,7 @@ const CacheExpireAfter = (7 * 24) * time.Hour
 
 // listConnections from Vault
 func listConnections(vc *vaultApi.Client) bool {
+	log.Debugf("listConnections")
 	connections, err := getConnections(vc)
 
 	if err != nil {
@@ -46,7 +47,7 @@ func listConnections(vc *vaultApi.Client) bool {
 
 // showConnection details suitable for use with ssh_config
 func showConnection(vc *vaultApi.Client, key string) bool {
-	log.Debugf("showConnection %v", key)
+	log.Debugf("showConnection: %v", key)
 	conn, err := getRawConnection(vc, key)
 
 	if err != nil {
@@ -70,7 +71,7 @@ func showConnection(vc *vaultApi.Client, key string) bool {
 
 // printConnection details suitable for use on the command line
 func printConnection(vc *vaultApi.Client, key string) bool {
-	log.Debugf("printConnection %v", key)
+	log.Debugf("printConnection: %v", key)
 	conn, err := getRawConnection(vc, key)
 
 	if err != nil {
@@ -155,7 +156,7 @@ func updateConnection(vc *vaultApi.Client, key string, args []string) bool {
 
 // deleteConnection removes an entry from Vault
 func deleteConnection(vc *vaultApi.Client, key string) bool {
-	log.Debugf("deleteConnection %v", key)
+	log.Debugf("deleteConnection: %v", key)
 	_, err := getRawConnection(vc, key)
 
 	if err != nil {

--- a/config/main.go
+++ b/config/main.go
@@ -30,6 +30,9 @@ var (
 	// EnvBasePath is the parent location used to prefix storage paths
 	EnvBasePath = filepath.Join(os.Getenv("HOME"), ".ssh", "cache")
 
+	// EnvSSHDefaultUsername sets the default used in connections
+	EnvSSHDefaultUsername = os.Getenv("USER")
+
 	// EnvSSHUsername is used to authenticate with SSH
 	EnvSSHUsername = "SSH_MS_USERNAME"
 
@@ -43,7 +46,7 @@ func GetConfig() *Settings {
 	once.Do(func() {
 		settings = Settings{
 			ConfigComment:         "",
-			EnvSSHDefaultUsername: os.Getenv("USER"),
+			EnvSSHDefaultUsername: EnvSSHDefaultUsername,
 			EnvSSHIdentityFile:    EnvSSHIdentityFile,
 			EnvSSHUsername:        os.Getenv(EnvSSHUsername),
 			LogLevel:              logrus.WarnLevel,

--- a/ssh/main.go
+++ b/ssh/main.go
@@ -277,7 +277,7 @@ func setPort(sshArgs *Connection, args map[string]interface{}) {
 // sshArgs : Connection properties for SSH
 // args : options provided for inspection
 func setIdentity(sshArgs *Connection, args map[string]interface{}) {
-	option := "~/.ssh/id_rsa"
+	option := cfg.EnvSSHIdentityFile
 	if val, ok := args["IdentityFile"]; ok {
 		option = val.(string)
 	}


### PR DESCRIPTION
Added the `update` command to support partial updates.

When an existing connection is detected then the update will take place, however if one is not found then the user will be directed to use the `write` command instead, and vice versa. Update of the comment is supported with this.

* Added `cmd.updateConnection` to handle partial updates, which
  will currently fail when an existing connection is not found and
  directs the user to use `write`
* Updated `cmd.writeConnection` to fail when an existing connection
  is found an directs the user to use `update`
* Added `cmd.updateCmd` and added support for `--comment` with it

Addition changes:

* Added `config.EnvSSHDefaultUsername`, with the default set to
  `os.Getenv("USER")`
* Updated `config.Settings` to add `EnvSSHDefaultUsername`
* Fixed issue in `ssh.setIdentity` where the default key path
  was static
* Fixed outdated overrides in `Makefile` following refactor

Addresses https://github.com/cezmunsta/ssh_ms/issues/5