### PR TITLE
Added locking mechanism for write operations

### DIFF
--- a/vault/helper.go
+++ b/vault/helper.go
@@ -115,6 +115,7 @@ func WriteSecret(c *api.Client, key string, data map[string]interface{}) (bool, 
 		"serveralivecountmax": "ServerAliveCountMax",
 		"cache":               "Cache",
 		"configcomment":       "ConfigComment",
+		"expires":             "Expires",
 	}
 
 	for k, v := range data {


### PR DESCRIPTION
* Added `cmd.LockPrefix` use to create host-specific lock names
* Added `cmd.getlockName`, `cmd.getLockPath`, `cmd.acquireLock` and
  `cmd.releaseLock` to control access for write operations
* Added `Expires` as a supported field for `vault.WriteSecret`
* Updated `cmd.getConnections` to ignore any lock entries
* Updated `cmd.writeConnection`, `cmd.updateConnection` and
  `cmd.deleteConnection` to require a lock in order to proceed