### PR TITLE
Added dynamic ControlPath definition

### DIFF
--- a/config/main.go
+++ b/config/main.go
@@ -38,7 +38,7 @@ var (
 	EnvSSHUsername = "SSH_MS_USERNAME"
 
 	// EnvSSHIdentityFile is used for SSH authentication
-	EnvSSHIdentityFile = "id_rsa"
+	EnvSSHIdentityFile = filepath.Join("~", ".ssh", "id_ed25519")
 )
 
 // ToJSON returns the config in JSON format

--- a/ssh/main_test.go
+++ b/ssh/main_test.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -68,5 +69,18 @@ func TestRewriteUsername(t *testing.T) {
 		if strings.Contains(user.FullName, "@") && !strings.Contains(n, "@") {
 			t.Fatalf("expected: templates to be parsed got: %v", user.FullName)
 		}
+	}
+}
+
+func TestConnection(t *testing.T) {
+	conn := Connection{
+		HostName: "localhost",
+		User:     "dummy",
+		Port:     uint16(29022),
+	}
+	conn.BuildConnection(map[string]interface{}{}, "dummy", conn.User)
+	expected := fmt.Sprintf("cp_%s_%s_%d", conn.User, conn.HostName, conn.Port)
+	if !strings.HasSuffix(conn.ControlPath, expected) {
+		t.Fatalf("expected: %v, got: %v", expected, conn.ControlPath)
 	}
 }


### PR DESCRIPTION
In order to solve the problem of unnecessary `LocalForward` definitions
when creating multiple connections to the same host, a scenario that
occurs when a control path is used, specifying the `ControlPath` dynamically
allows detection of an active connection. When the first connection is created
the `ControlPath` is generated by SSH and we save the ports in the cache
directory. For the next connection, if the `Controlpath` is still in existence
then we can specify identical `LocalForward` entries without an issue.

* Updated `cfg.EnvSSHIdentityFile` to be the full, default path for an
  ED25519 private key
* Added `ssh.setControlPath` to dynamically define the `ControlPath` for
  use with the connection
* Updated `ssh.setPortForwarding` to check for a `ControlPath` file and,
  when it exists along with a cached set of ports, reuse the ports. If
  we don't have what we expect, or there is no cache for the ports, we
  reset and generate new ones and set the cache
* Added `ssh.TestConnection`
* Fixed simplication issue with reflect

Addresses https://github.com/cezmunsta/ssh_ms/issues/7