### PR TITLE
Added support for message of the day

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,40 @@ bob@testing: ~ $
 Each connection that is retrieved from `Vault` is cached locally for 1 week. Should you need to
 force this to be cleared then you can use the `purge` command:
 ```sh
-ssh_ms purge
+$ ssh_ms purge
+```
+
+### Setting comments and message of the day
+To help identify connections, or to give some extra information when a user connects, you can set
+a comment and/or a message of the day that will be displayed. When these are not set there will still
+be a sort of motd that displays the current connection and any port forwarding.
+```sh
+$ ssh_ms update testing --comment "This is a comment" --motd "This is the motd"
+$ ssh_ms show testing
+# This is a comment
+Host testing
+   HostName localhost
+   Port 22
+   User bob
+   IdentityFile ~/.ssh/custom_rsa
+   IdentitiesOnly yes
+   ProxyJump none
+   ControlPath /home/bob/.ssh/cache/cp_bob_localhost_22
+
+$ ssh_ms connect testing date
+
+***************************************************************
+# This is a comment
+Server connection: testing
+
+This is the motd
+
+FWD: https://127.0.0.1:18000 - NGINX (443)
+FWD: https://127.0.0.1:18001 - PMM (8443)
+***************************************************************
+
+Wed 19 May 17:20:44 BST 2021
+Shared connection to localhost closed.
 ```
 
 ## Build

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -181,8 +181,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&cfg.Simulate, "dry-run", "n", false, "Prevent certain commands without full execution")
 	rootCmd.PersistentFlags().BoolVarP(&cfg.Verbose, "verbose", "v", false, "Provide addition output")
 
-	updateCmd.Flags().StringVarP(&cfg.ConfigComment, "comment", "c", "", "Set thecomment for the config entry")
+	updateCmd.Flags().StringVarP(&cfg.ConfigComment, "comment", "c", "", "Set the comment for the config entry")
 	writeCmd.Flags().StringVarP(&cfg.ConfigComment, "comment", "c", "", "Add a comment for the config entry")
+	updateCmd.Flags().StringVarP(&cfg.ConfigMotd, "motd", "m", "", "Set the Motd for the config entry")
+	writeCmd.Flags().StringVarP(&cfg.ConfigMotd, "motd", "m", "", "Add a Motd comment for the config entry")
 
 	log := log.GetLogger(log.GetDefaultLevel(), "")
 	cfg.LogLevel = log.GetLevel()

--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html/template"
 	"io/ioutil"
 	"math"
 	"os"
@@ -22,6 +24,10 @@ import (
 )
 
 type secretData map[string]interface{}
+
+type configMotdTpl struct {
+	Comment, Motd, Name string
+}
 
 const (
 	// CacheExpireAfter sets the threshold for cleaning stale caches
@@ -185,7 +191,7 @@ func searchConnections(vc *vaultApi.Client, pattern string) bool {
 // showConnection details suitable for use with ssh_config
 func showConnection(vc *vaultApi.Client, key string) bool {
 	log.Debugf("showConnection: %v", key)
-	sshArgs, sshClient, configComment := prepareConnection(vc, []string{key})
+	sshArgs, sshClient, configComment, _ := prepareConnection(vc, []string{key})
 
 	log.Info("SSH cmd:", sshArgs)
 	if len(configComment) > 0 {
@@ -200,7 +206,7 @@ func showConnection(vc *vaultApi.Client, key string) bool {
 // printConnection details suitable for use on the command line
 func printConnection(vc *vaultApi.Client, key string) bool {
 	log.Debugf("printConnection: %v", key)
-	sshArgs, _, _ := prepareConnection(vc, []string{key})
+	sshArgs, _, _, _ := prepareConnection(vc, []string{key})
 
 	fmt.Printf("ssh %v\n", strings.Join(sshArgs, " "))
 	return true
@@ -225,6 +231,7 @@ func writeConnection(vc *vaultApi.Client, key string, args []string) bool {
 	}
 
 	conn["ConfigComment"] = cfg.ConfigComment
+	conn["ConfigMotd"] = cfg.ConfigMotd
 
 	if cfg.Simulate {
 		log.Infof("simulated write to '%v': %v", key, args)
@@ -267,6 +274,10 @@ func updateConnection(vc *vaultApi.Client, key string, args []string) bool {
 
 	if len(cfg.ConfigComment) > 0 {
 		conn.Data["ConfigComment"] = cfg.ConfigComment
+	}
+
+	if len(cfg.ConfigMotd) > 0 {
+		conn.Data["ConfigMotd"] = cfg.ConfigMotd
 	}
 
 	if cfg.Simulate {
@@ -325,10 +336,11 @@ func deleteConnection(vc *vaultApi.Client, key string) bool {
 // vc : Vault client
 // args : options for inspection
 // verbose : enable informational output
-func prepareConnection(vc *vaultApi.Client, args []string) ([]string, ssh.Connection, string) {
+func prepareConnection(vc *vaultApi.Client, args []string) ([]string, ssh.Connection, string, string) {
 	log.Debugf("prepareConnection: %v", args)
 	var sshArgs []string
 	var configComment string
+	var configMotd string
 
 	if len(args) == 0 {
 		log.Fatal("Minimum requirement is to specify an alias")
@@ -336,21 +348,48 @@ func prepareConnection(vc *vaultApi.Client, args []string) ([]string, ssh.Connec
 	key := args[0]
 	config := lookupConnection(vc, key)
 	configComment = key
+	configMotd = ""
 
 	if val, ok := config["ConfigComment"]; ok {
 		log.Debugf("Found comment for '%v': %v", key, val)
 		configComment = fmt.Sprintf("%v", val)
 	}
 
+	if val, ok := config["ConfigMotd"]; ok {
+		log.Debugf("Found Motd for '%v': %v", key, val)
+		configMotd = fmt.Sprintf("%v\n", val)
+	}
+
 	if config == nil {
-		return sshArgs, ssh.Connection{}, key
+		return sshArgs, ssh.Connection{}, key, configMotd
 	}
 
 	log.Debugf("config: %v", config)
 	sshClient := ssh.Connection{}
 	sshArgs = append(sshClient.BuildConnection(config, key, cfg.User), args[1:]...)
 	log.Debugf("sshArgs: %v", sshArgs)
-	return sshArgs, sshClient, configComment
+
+	for i := 0; i < len(sshClient.LocalForward); i++ {
+		configMotd += fmt.Sprintf("\nFWD: https://127.0.0.1:%d -> %d", sshClient.LocalForward[i].LocalPort, sshClient.LocalForward[i].RemotePort)
+	}
+
+	if configAutoMotdTpl, err := template.New("configAutoMotd").Parse(`
+***************************************************************
+# {{.Comment}}
+Server connection: {{.Name}}
+
+{{.Motd}}
+***************************************************************
+
+	`); err != nil {
+		log.Warningf("Failed to proces MOTD for '%v': %v", key, err)
+	} else {
+		b := bytes.Buffer{}
+		configAutoMotdTpl.Execute(&b, configMotdTpl{Comment: configComment, Motd: configMotd, Name: key})
+		configMotd = b.String()
+	}
+
+	return sshArgs, sshClient, configComment, configMotd
 }
 
 // lookupConnection tries local cache and then remote to acquire connection details
@@ -371,7 +410,7 @@ func lookupConnection(vc *vaultApi.Client, key string) map[string]interface{} {
 // args : extra args passed by the user
 func connect(vc *vaultApi.Client, env ssh.UserEnv, args []string) {
 	log.Debug("connect:", args[0])
-	sshArgs, sshClient, configComment := prepareConnection(vc, args)
+	sshArgs, _, _, configMotd := prepareConnection(vc, args)
 
 	log.Debugf("%v", map[string]interface{}{
 		"env":  env,
@@ -383,10 +422,7 @@ func connect(vc *vaultApi.Client, env ssh.UserEnv, args []string) {
 		return
 	}
 
-	fmt.Println("Connecting to: ", configComment)
-	for i := 0; i < len(sshClient.LocalForward); i++ {
-		fmt.Printf("FWD: https://127.0.0.1:%d -> %d\n", sshClient.LocalForward[i].LocalPort, sshClient.LocalForward[i].RemotePort)
-	}
+	fmt.Println(configMotd)
 	ssh.Connect(sshArgs, env)
 }
 

--- a/cmd/connections_test.go
+++ b/cmd/connections_test.go
@@ -90,3 +90,27 @@ func TestShowConnection(t *testing.T) {
 		t.Fatalf("expected: got: ")
 	}
 }
+
+func TestPrepareConnection(t *testing.T) {
+	_, client := getDummyCluster(t)
+	cn, err := getRawConnection(client, lookupKey)
+
+	if err != nil || cn == nil {
+		t.Fatalf("expected: connection data got: '%v', err '%s'", cn, err)
+	}
+
+	_, sshClient, configComment, configMotd := prepareConnection(client, []string{lookupKey})
+
+	if sshClient.User != lookupKey {
+		t.Fatalf("expected user '%v', got '%v'", lookupKey, sshClient.User)
+	}
+
+	if configComment != dummyComment {
+		t.Fatalf("expected comment '%v', got '%v'", dummyComment, configComment)
+	}
+
+	if !strings.Contains(configMotd, dummyMotd) {
+		t.Fatalf("expected motd to contain '%v', got '%v'", dummyMotd, configMotd)
+	}
+
+}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -22,6 +22,9 @@ var (
 )
 
 const (
+	dummyComment = "This is a comment"
+	dummyMotd    = "This is the motd"
+
 	vaultKvVersion = "1"
 	vaultTestToken = "iamadummytoken"
 )
@@ -70,6 +73,8 @@ func generateDummyData(t *testing.T, frag string) {
 	key := fmt.Sprintf("%s/%s", vaultSecretPath, frag)
 	data := make(secretData)
 	data["User"] = frag
+	data["ConfigComment"] = dummyComment
+	data["ConfigMotd"] = dummyMotd
 
 	if status, err := vaultHelper.WriteSecret(client, key, data); err != nil || !status {
 		t.Fatalf("writeSecret expected: %v, got: %v, %v", data, status, err)

--- a/config/main.go
+++ b/config/main.go
@@ -13,7 +13,7 @@ import (
 type Settings struct {
 	LogLevel                                       logrus.Level
 	Debug, Simulate, StoredToken, Verbose, Version bool
-	ConfigComment, EnvSSHDefaultUsername, EnvSSHIdentityFile,
+	ConfigComment, ConfigMotd, EnvSSHDefaultUsername, EnvSSHIdentityFile,
 	EnvSSHUsername, SecretPath, Show, StoragePath, User, VaultAddr, VaultToken string
 }
 
@@ -60,6 +60,7 @@ func GetConfig() *Settings {
 	once.Do(func() {
 		settings = Settings{
 			ConfigComment:         "",
+			ConfigMotd:            "",
 			EnvSSHDefaultUsername: EnvSSHDefaultUsername,
 			EnvSSHIdentityFile:    EnvSSHIdentityFile,
 			EnvSSHUsername:        EnvSSHUsername,

--- a/vault/helper.go
+++ b/vault/helper.go
@@ -115,6 +115,7 @@ func WriteSecret(c *api.Client, key string, data map[string]interface{}) (bool, 
 		"serveralivecountmax": "ServerAliveCountMax",
 		"cache":               "Cache",
 		"configcomment":       "ConfigComment",
+		"configmotd":          "ConfigMotd",
 		"expires":             "Expires",
 	}
 


### PR DESCRIPTION
* Added `--motd` to `cli.writeCmd` and `cli.updateCmd`
* Updated `cli.prepareConnection` to generate a dynamic motd based
  upon the current host, the stored comment and motd for that host,
  plus include the dynamic port-forwarding information
* Added unit test for `cli.prepareConnection`
* Updated to mention the service along with the remote port
* Updated README