### PR TITLE
Ensure EnvBasePath exists

### DIFF
--- a/config/helper.go
+++ b/config/helper.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 
+	"github.com/cezmunsta/ssh_ms/log"
 	"github.com/gabriel-vasile/mimetype"
 )
 
@@ -22,6 +23,14 @@ var (
 	}
 )
 
+func ensureDirExists(path string) (bool, error) {
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		log.Errorf("Failed to create directory '%v': %v", path, err)
+		return false, err
+	}
+	return true, nil
+}
+
 // GetFileType will return the mimetype of a file
 // fh : file handle
 func GetFileType(fh *os.File) (uint, error) {
@@ -32,7 +41,7 @@ func GetFileType(fh *os.File) (uint, error) {
 
 	ct, exists := formatLookup[mt.String()]
 	if !exists {
-		ct, _ = formatLookup["default"]
+		ct = formatLookup["default"]
 	}
 	return ct, nil
 }

--- a/config/helper_test.go
+++ b/config/helper_test.go
@@ -60,3 +60,17 @@ func TestGetFileType(t *testing.T) {
 		t.Fatalf("expected: '%v' got: '%v'", FormatUnknown, ct)
 	}
 }
+
+func TestEnsureDirExists(t *testing.T) {
+	ts := "/ensureDirExists"
+	td := os.TempDir() + ts
+	defer os.RemoveAll(td)
+
+	if ok, err := ensureDirExists(td); !ok {
+		t.Fatalf("expected: %v exists, got: %v", td, err)
+	}
+
+	if ok, err := ensureDirExists(ts); ok {
+		t.Fatalf("expected: %v to not exist, got: %v", ts, err)
+	}
+}

--- a/config/main.go
+++ b/config/main.go
@@ -69,6 +69,8 @@ func GetConfig() *Settings {
 		if EnvBasePath == "" {
 			EnvBasePath = filepath.Join(os.Getenv("HOME"), ".ssh", "cache")
 		}
+		ensureDirExists(EnvBasePath)
+
 		if EnvSSHDefaultUsername == "" {
 			EnvSSHDefaultUsername = os.Getenv("USER")
 		}

--- a/ssh/main_test.go
+++ b/ssh/main_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	names = []string{"ceri", "ceri.williams", "ceriwilliams"}
+	names = []string{"first", "firstname.lastname", "firstnamelastname"}
 )
 
 func init() {


### PR DESCRIPTION
* Added `config.ensureDirExists` and `config.TestEnsureDirExists`
* Updated `config.GetConfig` to call `ensureDirExists(EnvBasePath)`
* Updated test names to use generic firstname, lastname
* Fixed unnecessary assignment to blank identifier

Fixes https://github.com/cezmunsta/ssh_ms/issues/44