### PR TITLE
Ignore misses for lock requests

### DIFF
--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -571,8 +571,11 @@ func getRawConnection(vc *vaultApi.Client, key string) (*vaultApi.Secret, error)
 	secret, err := vaultHelper.ReadSecret(vc, fmt.Sprintf("%s/%s", cfg.SecretPath, key))
 
 	if err != nil || secret == nil {
-		log.Warning("Unable to find connection for: ", key)
-		return nil, errors.New("no match found")
+		if !strings.HasPrefix(key, LockPrefix) {
+			log.Warning("Unable to find connection for: ", key)
+			return nil, errors.New("no match found")
+		}
+		return nil, errors.New("no lock found")
 	}
 	return secret, nil
 }

--- a/cmd/connections_test.go
+++ b/cmd/connections_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -37,6 +38,10 @@ func TestGetRawConnection(t *testing.T) {
 
 	if cn, err := getRawConnection(client, lookupKey); err != nil || cn == nil {
 		t.Fatalf("expected: connection data got: '%v', err '%s'", cn, err)
+	}
+
+	if _, err := getRawConnection(client, getLockName(lookupKey)); err == nil || fmt.Sprintf("%s", err) != "no lock found" {
+		t.Fatalf("expected: no lock found got: '%v'", err)
 	}
 }
 


### PR DESCRIPTION
Due to the locks using the same code as the config requests,
warning messages previously appeared when there is no lock, which
is the scenario that you want to have. The message is no longer
emitted when making a lock request.

* Updated `cmd.getRawConnection` to check if the key is prefixed
  with the `LockPrefix`, returning 'no lock found' instead of
  'no match found' when true
* Updated `cmd.TestGetRawConnection` to ensure that a lock request
  returns 'no lock found'

Fixes https://github.com/cezmunsta/ssh_ms/issues/48