### PR TITLE
Extra information for versionCmd

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -253,6 +253,8 @@ func getVersion() [][]string {
 	} else {
 		lines = append(lines, []string{"Version:", Version})
 		lines = append(lines, []string{"Arch:", runtime.GOOS, runtime.GOARCH})
+		lines = append(lines, []string{"Go Version:", runtime.Version()})
+		lines = append(lines, []string{"Vault Version:", cfg.VaultVersion})
 		lines = append(lines, []string{"Base path:", config.EnvBasePath})
 		lines = append(lines, []string{"Default Vault address:", config.EnvVaultAddr})
 		lines = append(lines, []string{"Default SSH username:", config.EnvSSHDefaultUsername})

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/cezmunsta/ssh_ms/config"
 )
 
 func TestExecute(t *testing.T) {
@@ -30,6 +33,28 @@ func TestExecute(t *testing.T) {
 			//t.Fatalf("expected: '%s' got: '%s'", string(vb), string(out))
 			continue
 		}
+	}
+}
+
+func TestGetVersion(t *testing.T) {
+	lines := getVersion()
+	if len(lines) > 1 {
+		t.Fatalf("expected: 1 line, got: %v", lines)
+	}
+
+	cfg := config.GetConfig()
+	cfg.Verbose = true
+	lines = getVersion()
+	if len(lines) == 1 {
+		t.Fatalf("expected: multiple lines, got: %v", lines)
+	}
+
+	if s := strings.Join(lines[2], " "); !strings.Contains(s, "Go Version: "+runtime.Version()) {
+		t.Fatalf("expected: 'Go Version: %v', got: %v", runtime.Version(), lines[2])
+	}
+
+	if s := strings.Join(lines[3], " "); !strings.Contains(s, "Vault Version: "+cfg.VaultVersion) {
+		t.Fatalf("expected: 'Vault Version: %v', got: %v", cfg.VaultVersion, lines[3])
 	}
 }
 

--- a/config/main.go
+++ b/config/main.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	vaultApi "github.com/hashicorp/vault/api"
+	vaultVersion "github.com/hashicorp/vault/sdk/version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -15,7 +16,7 @@ type Settings struct {
 	LogLevel                                                     logrus.Level
 	Debug, Simulate, StoredToken, Verbose, Version, VersionCheck bool
 	ConfigComment, ConfigMotd, EnvSSHDefaultUsername, EnvSSHIdentityFile,
-	EnvSSHUsername, EnvVaultAddr, SecretPath, Show, StoragePath, User, VaultAddr, VaultToken string
+	EnvSSHUsername, EnvVaultAddr, SecretPath, Show, StoragePath, User, VaultAddr, VaultToken, VaultVersion string
 }
 
 var (
@@ -93,6 +94,7 @@ func GetConfig() *Settings {
 			Simulate:              false,
 			StoragePath:           EnvBasePath,
 			StoredToken:           false,
+			VaultVersion:          vaultVersion.Version,
 		}
 	})
 	return &settings


### PR DESCRIPTION
* Added Go version to verbose output for `version`
* Added Vault version to verbose output for `version`
* Added test for `cmd.getVersion`