### PR TITLE
Remove warning during write

### DIFF
--- a/cmd/connections_test.go
+++ b/cmd/connections_test.go
@@ -47,6 +47,20 @@ func TestGetRawConnection(t *testing.T) {
 	if _, err := getRawConnection(client, getLockName(lookupKey)); err == nil || fmt.Sprintf("%s", err) != "no lock found" {
 		t.Fatalf("expected: no lock found got: '%v'", err)
 	}
+
+	for _, cmd := range []string{"connect", "write", "update", "delete", "list", "search", "show", "print", "purge"} {
+		currentCommand = cmd
+		switch cmd {
+		case "write":
+			if _, err := getRawConnection(client, "thisisnotavaliditem"); err == nil || fmt.Sprintf("%s", err) != "no lock found" {
+				t.Fatalf("expected: 'no lock found', got: %v", err)
+			}
+		default:
+			if _, err := getRawConnection(client, "thisisnotavaliditem"); err == nil || fmt.Sprintf("%s", err) != "no match found" {
+				t.Fatalf("expected: 'no match found' present, got: %v", err)
+			}
+		}
+	}
 }
 
 func TestCache(t *testing.T) {


### PR DESCRIPTION
When writing a new connection, an unnecessary warning iappears:
```shell
level=warning msg="Unable to find connection for: xxx"
```

* Added `currentCommand` var to `cmd` and set it during the
  connection commands for ease of detection.
* Updated `cmd.getRawConnection` to bypass warnings when
  `currentCommand == "write"`
* Updated `cmd.TestGetRawConnection` to ensure that the
  correct error is raised for the connection commands

Fixes #58