### PR TITLE
Added push workflow for Go source code

### DIFF
--- a/.github/workflows/push-go.yaml
+++ b/.github/workflows/push-go.yaml
@@ -1,0 +1,30 @@
+---
+name: Go
+on:
+  push:
+    paths:
+    - '**.go'
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Prepare Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Checkout codebase
+      uses: actions/checkout@v2
+
+    - name: Perform lint checks
+      run: make lint
+
+    - name: Perform format checks
+      run: make simplify
+
+    - name: Perform vet checks
+      run: make vet
+
+    - name: Run test suite
+      run: make test
+...

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,8 @@ else
 LDFLAGS=-ldflags "-w -X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR}"
 endif
 
+VETFLAGS?=( -unusedresult -bools -copylocks -framepointer -httpresponse -json -stdmethods -printf -stringintconv -unmarshal -unsafeptr )
+
 all: lint format test binaries
 
 binaries: binary-linux binary-mac
@@ -71,13 +73,15 @@ lint:
 format: export PACKAGE=./
 format:
 	@gofmt -w "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault" "${PACKAGE}/log" "${PACKAGE}/config"
+	@git diff --exit-code --quiet "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault" "${PACKAGE}/log" "${PACKAGE}/config"
 
 simplify: export PACKAGE=./
 simplify:
 	@gofmt -s -w "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault" "${PACKAGE}/log" "${PACKAGE}/config"
+	@git diff --exit-code --quiet "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault" "${PACKAGE}/log" "${PACKAGE}/config"
 
 vet:
-	@"${GO}" vet "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault"
+	@"${GO}" vet "${VETFLAGS[@]}" "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault"
 
 fix: export PACKAGE=./
 fix:


### PR DESCRIPTION
* Updated `Makefile` to produce exit codes for `format` and
 `simplify` so that they do not require visual inspection
* Updated `Makefile` to use `VETFLAGS` when vetting
* Added `push-go` workflow to perform linting, format checks,
  vetting and finally to execute the test suite