### PR TITLE
Add support for ForwardAgent

### DIFF
--- a/ssh/main.go
+++ b/ssh/main.go
@@ -66,6 +66,7 @@ type Connection struct {
 	ServerAliveCountMax uint16
 	Cache               CachedConnection
 	ControlPath         string
+	ForwardAgent        string
 	//Compression bool
 	//ControlMaster bool
 	//ControlPersist uint16
@@ -413,6 +414,16 @@ func setPortForwarding(sshArgs *Connection) {
 	}
 }
 
+// setForwardAgent for the connection
+// args : options provided for inspection
+func setForwardAgent(sshArgs *Connection, args map[string]interface{}) {
+	option := "no"
+	if val, ok := args["ForwardAgent"]; ok {
+		option = val.(string)
+	}
+	sshArgs.ForwardAgent = option
+}
+
 // BuildConnection creates the SSH command for execution
 // args : options provided for inspection
 func (c *Connection) BuildConnection(args map[string]interface{}, key string, templateUser string) []string {
@@ -425,6 +436,7 @@ func (c *Connection) BuildConnection(args map[string]interface{}, key string, te
 	setHostname(c, args)
 	setControlPath(c, args)
 	setPortForwarding(c)
+	setForwardAgent(c, args)
 
 	d := reflect.ValueOf(c).Elem()
 	t := d.Type()

--- a/ssh/main_test.go
+++ b/ssh/main_test.go
@@ -99,6 +99,11 @@ func TestConnection(t *testing.T) {
 		}
 	}
 
+	// Test default ForwardAgent is set to "no"
+	if conn.ForwardAgent != "no" {
+		t.Fatalf("ForwardAgent is not set to 'no'")
+	}
+
 	// Test custom LocalForward rules
 	cfg := config.GetConfig()
 	cfg.CustomLocalForward = "9998,9999"

--- a/vault/helper.go
+++ b/vault/helper.go
@@ -117,6 +117,7 @@ func WriteSecret(c *api.Client, key string, data map[string]interface{}) (bool, 
 		"configcomment":       "ConfigComment",
 		"configmotd":          "ConfigMotd",
 		"expires":             "Expires",
+		"forwardagent":        "ForwardAgent",
 	}
 
 	for k, v := range data {


### PR DESCRIPTION
Whilst `ForwardAgent` is normally disabled for security reasons, there
are certain circumstances where it is required. An example of
required usage is where a third-party requires 2FA and a \
certificate and key are injected into the user’s ssh-agent upon
successful authentication.

* Added `ForwardAgent` to `ssh.Connection`, defaulting to "no"
* Updated `ssh` tests to ensure default is "no"
* Added `ForwardAgent` to `vault.WriteSecret` to allow use when
  storing configurations