### PR TITLE
Add option to view usable placeholders for User

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ used along with `--stored-token`.
 When either using in a shared environment, or when wishing to reuse a connection with a choice of User values, templated entries are supported.
 You can view the supported templates using the `inspect` command, e.g.
 ```shell
-$ ssh_ms inspect placeholders@@USER_FIRSTNAME.@@USER_LASTNAME
+$ ssh_ms inspect placeholders
+@@USER_FIRSTNAME.@@USER_LASTNAME
 @@USER_FIRSTNAME
 @@SSH_MS_USERNAME
 @@USER_INITIAL_LASTNAME

--- a/README.md
+++ b/README.md
@@ -101,6 +101,36 @@ It is also possible to use either the `VAULT_TOKEN` environment variable, or `--
 your token should you need to. Whenever possible, the pre-authenticated, more secure method should be
 used along with `--stored-token`.
 
+### Using templated usernames
+When either using in a shared environment, or when wishing to reuse a connection with a choice of User values, templated entries are supported.
+You can view the supported templates using the `inspect` command, e.g.
+```shell
+$ ssh_ms inspect placeholders@@USER_FIRSTNAME.@@USER_LASTNAME
+@@USER_FIRSTNAME
+@@SSH_MS_USERNAME
+@@USER_INITIAL_LASTNAME
+@@USER_LASTNAME_INITIAL
+@@USER_FIRSTNAME_INITIAL
+```
+
+When using `--verbose` mode you will also see the templates associated with these:
+```shell
+$ ssh_ms inspect placeholders -v
+@@USER_LASTNAME_INITIAL = {{.LastName}}{{.FirstNameInitial}}
+@@USER_FIRSTNAME_INITIAL = {{.FirstName}}{{.LastNameInitial}}
+@@USER_FIRSTNAME.@@USER_LASTNAME = {{.FirstName}}.{{.LastName}}
+@@USER_FIRSTNAME = {{.FirstName}}
+@@SSH_MS_USERNAME = {{.FullName}}
+@@USER_INITIAL_LASTNAME = {{.FirstNameInitial}}{{.LastName}}
+```
+
+Using templated usernames will require either an environment variable to be set (`SSH_MS_USERNAME` by default), or by using the `--user` argument.
+Writing these to storage is done the same way as any other connection, except that you specify the template instead of the real user:
+```shell
+$ ssh_ms write test User=@@USER_LASTNAME_INITIAL
+```
+
+
 ### Add a gateway
 
 To make life easier, you may wish to export the address for Vault in your shell profile:

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -142,6 +142,17 @@ var (
 		},
 	}
 
+	// Internals
+	inspectCmd = &cobra.Command{
+		Use:   "inspect ITEM",
+		Short: "Inspect the value of an internal item",
+		Long:  "TBD",
+		Run: func(cmd *cobra.Command, args []string) {
+			checkArgs(args, 1)
+			inspectItem(args[0])
+		},
+	}
+
 	cfg = config.GetConfig()
 
 	/*
@@ -160,6 +171,7 @@ func init() {
 	rootCmd.AddCommand(
 		connectCmd,
 		deleteCmd,
+		inspectCmd,
 		listCmd,
 		printCmd,
 		purgeCmd,
@@ -266,6 +278,21 @@ func getVersion() [][]string {
 		lines = append(lines, []string{"SSH identity file:", config.EnvSSHIdentityFile})
 	}
 	return lines
+}
+
+// inspectItem allows display the value of an item in the allow-list
+func inspectItem(item string) {
+	switch item {
+	case "placeholders":
+	case "ph":
+		for k, v := range ssh.Placeholders {
+			if cfg.Verbose {
+				fmt.Printf("%v = %v\n", k, v)
+			} else {
+				fmt.Println(k)
+			}
+		}
+	}
 }
 
 // printVersion of the application


### PR DESCRIPTION
The User option for the SSH connection can be stored as a template
so that it changes for each user, based upon some pre-defined criteria.
Without looking at the code, it is not possible to see the supported
placeholders.

Adding an option for the user to list the available ones makes the use
of templated users easier.

* Added `cmd.inspectItem` to reveal the value of a predefined set of
  terms, currently just placeholders for `User`
* Added `cmd.inspectCmd` to call `inspectItem`
* Updated `README`

Resolves https://github.com/cezmunsta/ssh_ms/issues/67