### PR TITLE
Fix bad switch in cmd.inspectItem

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -283,8 +283,7 @@ func getVersion() [][]string {
 // inspectItem allows display the value of an item in the allow-list
 func inspectItem(item string) {
 	switch item {
-	case "placeholders":
-	case "ph":
+	case "placeholders", "ph":
 		for k, v := range ssh.Placeholders {
 			if cfg.Verbose {
 				fmt.Printf("%v = %v\n", k, v)


### PR DESCRIPTION
The switch statement for cmd.inspectItem had 2 case that should
have been combinded into a single case

Fixes https://github.com/cezmunsta/ssh_ms/issues/69