### PR TITLE
Notify user when their token will soon expire

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,19 +11,20 @@ XZ_COMPRESS?=1
 SSH_MS_BASEPATH?=~/.ssh/cache
 SSH_MS_DEFAULT_VAULT_ADDR?=https://127.0.0.1:8200
 SSH_MS_DEFAULT_USERNAME?="${USER}"
-SSH_MS_USERNAME?=SSH_MS_USERNAME
 SSH_MS_ID_FILE?=~/.ssh/id_rsa
+SSH_MS_RENEW_THRESHOLD?=168h
 SSH_MS_SYNC_HOST?=localhost
 SSH_MS_SYNC_PATH?=/usr/share/nginx/html/downloads/ssh_ms/
+SSH_MS_USERNAME?=SSH_MS_USERNAME
 
 DEBUG_BUILD=$(shell test "${DEBUG}" = "1" && echo 1 || echo 0)
 COMPRESS_BINARY=$(shell test "${XZ_COMPRESS}" = "1" && echo 1 || echo 0)
 
 PACKAGE=github.com/cezmunsta/ssh_ms
 ifeq ($(DEBUG_BUILD), 1)
-LDFLAGS=-ldflags "-X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR}"
+LDFLAGS=-ldflags "-X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR} -X ${PACKAGE}/vault.RenewThreshold=${SSH_MS_RENEW_THRESHOLD}"
 else
-LDFLAGS=-ldflags "-w -X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR}"
+LDFLAGS=-ldflags "-w -X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR} -X ${PACKAGE}/vault.RenewThreshold=${SSH_MS_RENEW_THRESHOLD}"
 endif
 
 VETFLAGS?=( -unusedresult -bools -copylocks -framepointer -httpresponse -json -stdmethods -printf -stringintconv -unmarshal -unsafeptr )

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ go get -u github.com/cezmunsta/ssh_ms
 For ease of use, ensure that `${GOPATH}/bin` is in your `PATH` to use the tools with ease.
 
 - `go` : `1.16.6`
-- `vault`: `1.8.4`
+- `vault`: `1.8.5`
 
 #### Go
 
@@ -259,10 +259,11 @@ along with `make build`:
 - `SSH_MS_BASEPATH`: Sets `config.EnvBasePath`
 - `SSH_MS_DEFAULT_VAULT_ADDR`: Sets `config.EnvVaultAddr`, bypassing environment lookup of `VAULT_ADDR`
 - `SSH_MS_DEFAULT_USERNAME`: Sets `config.EnvSSHDefaultUsername`, bypassing environment lookup of `USER`
-- `SSH_MS_USERNAME`: Sets `config.EnvSSHUsername` template variable, used in templated usernames
 - `SSH_MS_ID_FILE`:  Sets `config.EnvSSHIdentityFile`
+- `SSH_MS_RENEW_THRESHOLD`: Sets `vault.RenewThreshold`
 - `SSH_MS_SYNC_HOST`: Sets the destination host for a binary push via `rsync`
 - `SSH_MS_SYNC_PATH`: Sets the destination path for a binary push via `rsync`
+- `SSH_MS_USERNAME`: Sets `config.EnvSSHUsername` template variable, used in templated usernames
 
 To set the build version (e.g. if you are making a custom build, etc) you can use `make build` to set
 the build version (by default it will set it to `git rev-parse HEAD`), e.g.

--- a/vault/helper.go
+++ b/vault/helper.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/vault/api"
 
@@ -18,6 +19,8 @@ type UserEnv struct {
 	Addr, Token string
 	Simulate    bool
 }
+
+var RenewThreshold = "168h"
 
 // Authenticate a user with Vault
 // e : user environment
@@ -55,7 +58,28 @@ func Authenticate(e UserEnv, st bool) *api.Client {
 	}
 
 	client.Auth()
+
+	if lookupSelf, err := client.Auth().Token().LookupSelf(); err == nil {
+		if requiresRenewal(lookupSelf.Data) {
+			log.Warningf("Token will expire at: %v", lookupSelf.Data["expire_time"])
+		}
+	}
 	return client
+}
+
+func requiresRenewal(d map[string]interface{}) bool {
+	log.Debugf("Checking data: %v", d)
+	if val, ok := d["renewable"]; ok && !val.(bool) {
+		return false
+	}
+	if val, ok := d["expire_time"]; ok && val != nil {
+		t, _ := time.Parse(time.RFC3339, val.(string))
+		th, _ := time.ParseDuration(RenewThreshold)
+		if time.Now().Add(th).Before(t) {
+			return false
+		}
+	}
+	return true
 }
 
 // DeleteSecret removes a secret from Vault

--- a/vault/helper.go
+++ b/vault/helper.go
@@ -20,6 +20,7 @@ type UserEnv struct {
 	Simulate    bool
 }
 
+// RenewThreshold is used to compare against the token expiration time
 var RenewThreshold = "168h"
 
 // Authenticate a user with Vault

--- a/vault/helper_test.go
+++ b/vault/helper_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cezmunsta/ssh_ms/config"
 	vaultKv "github.com/hashicorp/vault-plugin-secrets-kv"
@@ -82,4 +83,18 @@ func TestHelpers(t *testing.T) {
 	if status, err := DeleteSecret(client, key); err != nil || !status {
 		t.Fatalf("DeleteSecret expected: %v, got: %v, %v", data, status, err)
 	}
+
+	expires := time.Now().Add(24 * time.Hour)
+	if !requiresRenewal(map[string]interface{}{
+		"renewable":   true,
+		"expire_time": expires.Format(time.RFC3339)}) {
+		t.Fatalf(("requiresRenewal expected: true"))
+	}
+	expires = expires.Add(24 * 8 * time.Hour)
+	if requiresRenewal(map[string]interface{}{
+		"renewable":   true,
+		"expire_time": expires.Format(time.RFC3339)}) {
+		t.Fatalf(("requiresRenewal expected: false"))
+	}
+
 }


### PR DESCRIPTION
To help avoid unexpected expiration of tokens, the user is provided
with a warning when they use a renewable token and it is due to
expire in less than 7 days.

* Updated `scripts/dev-vault.sh` to create a policy and test user
  for `secret/ssh_ms` for testing renewal messages, plus helper
  functions for testing renewal thresholds
* Added `vault.RenewThreshold` to allow build-time override of the
  threshold used when checking tokens
* Added `vault.requiresRenewal` to check if a token needs to be
  renewed in the next 7 days (default)
* Updated `vault.Authenticate` to emit a warning when the token
  needs to be renewed
* Added `SSH_MS_RENEW_THRESHOLD` to `Makefile` for build-time
  override of the renew threshold
* Updated `README`

Resolves #77 