### PR TITLE
Add support for multiple secret namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ SSH_MS_DEFAULT_VAULT_ADDR?=https://127.0.0.1:8200
 SSH_MS_DEFAULT_USERNAME?="${USER}"
 SSH_MS_ID_FILE?=~/.ssh/id_rsa
 SSH_MS_RENEW_THRESHOLD?=168h
+SSH_MS_SECRET_PATH?=secret/ssh_ms
 SSH_MS_SYNC_HOST?=localhost
 SSH_MS_SYNC_PATH?=/usr/share/nginx/html/downloads/ssh_ms/
 SSH_MS_USERNAME?=SSH_MS_USERNAME
@@ -22,9 +23,9 @@ COMPRESS_BINARY=$(shell test "${XZ_COMPRESS}" = "1" && echo 1 || echo 0)
 
 PACKAGE=github.com/cezmunsta/ssh_ms
 ifeq ($(DEBUG_BUILD), 1)
-LDFLAGS=-ldflags "-X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR} -X ${PACKAGE}/vault.RenewThreshold=${SSH_MS_RENEW_THRESHOLD}"
+LDFLAGS=-ldflags "-X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR} -X ${PACKAGE}/config.SecretPath=${SSH_MS_SECRET_PATH} -X ${PACKAGE}/vault.RenewThreshold=${SSH_MS_RENEW_THRESHOLD}"
 else
-LDFLAGS=-ldflags "-w -X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR} -X ${PACKAGE}/vault.RenewThreshold=${SSH_MS_RENEW_THRESHOLD}"
+LDFLAGS=-ldflags "-w -X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR} -X ${PACKAGE}/config.SecretPath=${SSH_MS_SECRET_PATH} -X ${PACKAGE}/vault.RenewThreshold=${SSH_MS_RENEW_THRESHOLD}"
 endif
 
 VETFLAGS?=( -unusedresult -bools -copylocks -framepointer -httpresponse -json -stdmethods -printf -stringintconv -unmarshal -unsafeptr )
@@ -80,7 +81,7 @@ lint:
 
 format: export PACKAGE=./
 format:
-	@gofmt -w "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault" "${PACKAGE}/log" "${PACKAGE}/config"
+	@gofumpt -w "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault" "${PACKAGE}/log" "${PACKAGE}/config"
 	@git diff --exit-code --quiet "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault" "${PACKAGE}/log" "${PACKAGE}/config"
 
 simplify: export PACKAGE=./

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 
 build: binary-prep
 ifeq ($(DEBUG_BUILD), 1)
-	@"${GO}" build -o "${BUILD_DIR}/ssh_ms.debug" ${LDFLAGS}
+	@"${GO}" build -race -trimpath -o "${BUILD_DIR}/ssh_ms.debug" ${LDFLAGS} -gcflags="all=-N -l"
 else
 	@"${GO}" build -race -trimpath -o "${BUILD_DIR}/ssh_ms" ${LDFLAGS}
 endif

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ else
 endif
 
 dev-vault:
-	@${SHELL} scripts/dev-vault.sh
+	@${SHELL} scripts/dev-vault.sh 1
 
 test:
 	@"${GO}" test "${PACKAGE}/ssh" "${PACKAGE}/cmd" "${PACKAGE}/vault" "${PACKAGE}/log" "${PACKAGE}/config"

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -228,8 +228,13 @@ func init() {
 
 	updateCmd.Flags().StringVarP(&cfg.ConfigComment, "comment", "c", "", "Set the comment for the config entry")
 	writeCmd.Flags().StringVarP(&cfg.ConfigComment, "comment", "c", "", "Add a comment for the config entry")
+
 	updateCmd.Flags().StringVarP(&cfg.ConfigMotd, "motd", "m", "", "Set the Motd for the config entry")
 	writeCmd.Flags().StringVarP(&cfg.ConfigMotd, "motd", "m", "", "Add a Motd comment for the config entry")
+
+	deleteCmd.Flags().StringVarP(&cfg.NameSpace, "namespace", "N", "", "Specify the namespace for the config entry")
+	updateCmd.Flags().StringVarP(&cfg.NameSpace, "namespace", "N", "", "Add a namespace for the config entry")
+	writeCmd.Flags().StringVarP(&cfg.NameSpace, "namespace", "N", "", "Set the namespace for the config entry")
 
 	versionCmd.Flags().BoolVarP(&cfg.VersionCheck, "check", "c", false, "Check for the latest version")
 
@@ -251,7 +256,6 @@ func checkVersion() [][]string {
 
 	url := "https://github.com/cezmunsta/ssh_ms/releases/latest"
 	req, err := http.NewRequest("HEAD", url, nil)
-
 	if err != nil {
 		log.Fatal("Error reading request. ", err)
 	}
@@ -289,9 +293,7 @@ func getVersion() [][]string {
 	var lines [][]string
 
 	if cfg.VersionCheck {
-		for _, line := range checkVersion() {
-			lines = append(lines, line)
-		}
+		lines = append(lines, checkVersion()...)
 	}
 
 	if !cfg.Verbose && !cfg.Debug {
@@ -302,6 +304,7 @@ func getVersion() [][]string {
 		lines = append(lines, []string{"Go Version:", runtime.Version()})
 		lines = append(lines, []string{"Vault Version:", cfg.VaultVersion})
 		lines = append(lines, []string{"Base path:", config.EnvBasePath})
+		lines = append(lines, []string{"Secret path:", config.SecretPath})
 		lines = append(lines, []string{"Default Vault address:", config.EnvVaultAddr})
 		lines = append(lines, []string{"Default SSH username:", config.EnvSSHDefaultUsername})
 		lines = append(lines, []string{"SSH template username:", config.EnvSSHUsername})

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -233,6 +233,8 @@ func init() {
 	writeCmd.Flags().StringVarP(&cfg.ConfigMotd, "motd", "m", "", "Add a Motd comment for the config entry")
 
 	deleteCmd.Flags().StringVarP(&cfg.NameSpace, "namespace", "N", "", "Specify the namespace for the config entry")
+	listCmd.Flags().StringVarP(&cfg.NameSpace, "namespace", "N", "", "Specify the namespace for the config entry")
+	showCmd.Flags().StringVarP(&cfg.NameSpace, "namespace", "N", "", "Specify the namespace for the config entry")
 	updateCmd.Flags().StringVarP(&cfg.NameSpace, "namespace", "N", "", "Add a namespace for the config entry")
 	writeCmd.Flags().StringVarP(&cfg.NameSpace, "namespace", "N", "", "Set the namespace for the config entry")
 
@@ -304,7 +306,7 @@ func getVersion() [][]string {
 		lines = append(lines, []string{"Go Version:", runtime.Version()})
 		lines = append(lines, []string{"Vault Version:", cfg.VaultVersion})
 		lines = append(lines, []string{"Base path:", config.EnvBasePath})
-		lines = append(lines, []string{"Secret path:", config.SecretPath})
+		lines = append(lines, []string{"Namespaces:\n-", strings.Join(strings.Split(config.SecretPath, ","), "\n- ")})
 		lines = append(lines, []string{"Default Vault address:", config.EnvVaultAddr})
 		lines = append(lines, []string{"Default SSH username:", config.EnvSSHDefaultUsername})
 		lines = append(lines, []string{"SSH template username:", config.EnvSSHUsername})

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"runtime"
 	"strings"
@@ -30,7 +29,7 @@ func TestExecute(t *testing.T) {
 	for _, line := range ver {
 		vb = []byte(strings.Join(line, " "))
 		if string(out) != string(vb) {
-			//t.Fatalf("expected: '%s' got: '%s'", string(vb), string(out))
+			// t.Fatalf("expected: '%s' got: '%s'", string(vb), string(out))
 			continue
 		}
 	}
@@ -66,7 +65,7 @@ func TestCheckVersion(t *testing.T) {
 		t.Fatalf("expected: 1 line, got: %v", lines)
 	}
 
-	if fmt.Sprintf("%s", strings.Join(lines[0], " ")) != latestVersion {
+	if strings.Join(lines[0], " ") != latestVersion {
 		t.Fatalf("expected: %s, got: %v", latestVersion, lines)
 	}
 

--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -157,7 +157,13 @@ func releaseLock(vc *vaultApi.Client, ln string) (bool, error) {
 // getConnections from Vault
 func getConnections(vc *vaultApi.Client) ([]string, error) {
 	var connections []string
-	secrets, err := vaultHelper.ListSecrets(vc, cfg.SecretPath)
+
+	sp := cfg.SecretPath
+	if (currentCommand != "list" && currentCommand != "search") || cfg.NameSpace != "" {
+		sp = getSecretPath()
+	}
+
+	secrets, err := vaultHelper.ListSecrets(vc, sp)
 
 	if err != nil {
 		log.Fatalf("Unable to get connections for %v: %v", vc.Address(), err)

--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -165,7 +165,7 @@ func getConnections(vc *vaultApi.Client) ([]string, error) {
 
 	secrets, err := vaultHelper.ListSecrets(vc, sp)
 
-	if err != nil {
+	if err != nil && len(secrets) == 0 {
 		log.Fatalf("Unable to get connections for %v: %v", vc.Address(), err)
 	} else if len(secrets) == 0 {
 		return nil, errors.New("no data returned")

--- a/cmd/connections.go
+++ b/cmd/connections.go
@@ -29,9 +29,7 @@ type configMotdTpl struct {
 	Comment, Motd, Name string
 }
 
-var (
-	currentCommand string
-)
+var currentCommand string
 
 const (
 	// CacheExpireAfter sets the threshold for cleaning stale caches
@@ -67,7 +65,27 @@ func getLockName(key string) string {
 
 // getLockPath produces the full lock path
 func getLockPath(ln string) string {
-	return fmt.Sprintf("%s/%s", cfg.SecretPath, ln)
+	return fmt.Sprintf("%s/%s", getSecretPath(), ln)
+}
+
+// getSecretPath produces the secret path
+func getSecretPath() string {
+	sp := strings.Split(cfg.SecretPath, ",")
+	p := sp[0]
+
+	if len(sp) > 1 && cfg.NameSpace == "" {
+		log.Warningf("multiple namespaces exist (%v), setting --namespace to the default '%s'", cfg.SecretPath, sp[0])
+		cfg.NameSpace = sp[0]
+	}
+
+	for _, ap := range sp {
+		if ap == cfg.NameSpace {
+			p = ap
+			break
+		}
+	}
+
+	return p
 }
 
 // acquireLock creates a lock to control writes
@@ -118,7 +136,6 @@ func acquireLock(vc *vaultApi.Client, key string) (bool, string) {
 func releaseLock(vc *vaultApi.Client, ln string) (bool, error) {
 	log.Debug("releaseLock:", ln)
 	existingLock, err := getRawConnection(vc, ln)
-
 	if err != nil {
 		log.Error("existingLock error:", err)
 		return false, err
@@ -144,15 +161,21 @@ func getConnections(vc *vaultApi.Client) ([]string, error) {
 
 	if err != nil {
 		log.Fatalf("Unable to get connections for %v: %v", vc.Address(), err)
-	} else if secrets == nil || secrets.Data["keys"] == nil {
+	} else if len(secrets) == 0 {
 		return nil, errors.New("no data returned")
 	}
 
-	switch reflect.TypeOf(secrets.Data["keys"]).Kind() {
-	case reflect.Slice:
-		s := reflect.ValueOf(secrets.Data["keys"])
-		for i := 0; i < s.Len(); i++ {
-			connections = append(connections, fmt.Sprintf("%s", s.Index(i)))
+	for _, secret := range secrets {
+		if secret == nil || secret.Data["keys"] == nil {
+			continue
+		}
+
+		switch reflect.TypeOf(secret.Data["keys"]).Kind() {
+		case reflect.Slice:
+			s := reflect.ValueOf(secret.Data["keys"])
+			for i := 0; i < s.Len(); i++ {
+				connections = append(connections, fmt.Sprintf("%s", s.Index(i)))
+			}
 		}
 	}
 	return connections, nil
@@ -254,7 +277,7 @@ func writeConnection(vc *vaultApi.Client, key string, args []string) bool {
 		return false
 	}
 
-	status, err := vaultHelper.WriteSecret(vc, fmt.Sprintf("%s/%s", cfg.SecretPath, key), conn)
+	status, err := vaultHelper.WriteSecret(vc, fmt.Sprintf("%s/%s", getSecretPath(), key), conn)
 	if err != nil {
 		log.Errorf("Failed to write '%v': %v", key, err)
 		return false
@@ -268,7 +291,6 @@ func updateConnection(vc *vaultApi.Client, key string, args []string) bool {
 	log.Debugf("updateConnection: %v", key)
 	currentCommand = "update"
 	conn, err := getRawConnection(vc, key)
-
 	if err != nil {
 		log.Warningf("Unable to retrieve connection '%v', please use write instead", key)
 		return false
@@ -303,7 +325,7 @@ func updateConnection(vc *vaultApi.Client, key string, args []string) bool {
 		return false
 	}
 
-	status, err := vaultHelper.WriteSecret(vc, fmt.Sprintf("%s/%s", cfg.SecretPath, key), conn.Data)
+	status, err := vaultHelper.WriteSecret(vc, fmt.Sprintf("%s/%s", getSecretPath(), key), conn.Data)
 	if err != nil {
 		log.Errorf("Failed to write '%v': %v", key, err)
 		return false
@@ -317,7 +339,6 @@ func deleteConnection(vc *vaultApi.Client, key string) bool {
 	log.Debugf("deleteConnection: %v", key)
 	currentCommand = "delete"
 	_, err := getRawConnection(vc, key)
-
 	if err != nil {
 		log.Debug("Unable to retrieve connection", key)
 		return false
@@ -334,7 +355,7 @@ func deleteConnection(vc *vaultApi.Client, key string) bool {
 		return false
 	}
 
-	status, err := vaultHelper.DeleteSecret(vc, fmt.Sprintf("%s/%s", cfg.SecretPath, key))
+	status, err := vaultHelper.DeleteSecret(vc, fmt.Sprintf("%s/%s", getSecretPath(), key))
 	if err != nil {
 		log.Warning("Unable to delete connection", key)
 		return false
@@ -491,7 +512,6 @@ func getCache(key string) (map[string]interface{}, error) {
 func getRemoteCache(vc *vaultApi.Client, key string) (map[string]interface{}, error) {
 	log.Debugf("getRemoteCache: %v", key)
 	conn, err := getRawConnection(vc, key)
-
 	if err != nil {
 		log.Errorf("Failed to request data for '%v': %v", key, err)
 		return nil, err
@@ -570,7 +590,7 @@ func populateCache(vc *vaultApi.Client) (bool, error) {
 // purgeCache will remove the cache directory and its contents, or an individual item's cache if requested
 func purgeCache() (bool, error) {
 	log.Debugf("purgeCache")
-	var targeted = purgeConnection != "" && purgeConnection != "all"
+	targeted := purgeConnection != "" && purgeConnection != "all"
 	currentCommand = "purge"
 
 	if !purgeForce {
@@ -611,7 +631,7 @@ func saveCache(key string, data map[string]interface{}) (bool, error) {
 		return false, err
 	}
 
-	if err := ioutil.WriteFile(getCachePath(key), []byte(string(buff)), 0640); err != nil {
+	if err := ioutil.WriteFile(getCachePath(key), []byte(string(buff)), 0o640); err != nil {
 		log.Errorf("Failed to save cache for '%v': %v", key, err)
 		return false, err
 	}
@@ -620,7 +640,7 @@ func saveCache(key string, data map[string]interface{}) (bool, error) {
 
 // getRawConnection retrieves the secret from Vault
 func getRawConnection(vc *vaultApi.Client, key string) (*vaultApi.Secret, error) {
-	secret, err := vaultHelper.ReadSecret(vc, fmt.Sprintf("%s/%s", cfg.SecretPath, key))
+	secret, err := vaultHelper.ReadSecret(vc, fmt.Sprintf("%s/%s", getSecretPath(), key))
 
 	if err != nil || secret == nil {
 		if !strings.HasPrefix(key, LockPrefix) && currentCommand != "write" {

--- a/cmd/connections_test.go
+++ b/cmd/connections_test.go
@@ -149,5 +149,4 @@ func TestPrepareConnection(t *testing.T) {
 	if !strings.Contains(configMotd, dummyMotd) {
 		t.Fatalf("expected motd to contain '%v', got '%v'", dummyMotd, configMotd)
 	}
-
 }

--- a/config/helper.go
+++ b/config/helper.go
@@ -17,12 +17,10 @@ const (
 	FormatUnknown = uint(0)
 )
 
-var (
-	formatLookup = map[string]uint{
-		"application/json": FormatJSON,
-		"default":          FormatText,
-	}
-)
+var formatLookup = map[string]uint{
+	"application/json": FormatJSON,
+	"default":          FormatText,
+}
 
 func ensureDirExists(path string) (bool, error) {
 	if err := os.MkdirAll(NormalizePath(path), os.ModePerm); err != nil {

--- a/config/main.go
+++ b/config/main.go
@@ -16,7 +16,7 @@ type Settings struct {
 	LogLevel                                                     logrus.Level
 	Debug, Simulate, StoredToken, Verbose, Version, VersionCheck bool
 	ConfigComment, ConfigMotd, EnvSSHDefaultUsername, EnvSSHIdentityFile,
-	CustomLocalForward, EnvSSHUsername, EnvVaultAddr, SecretPath, Show, StoragePath, User, VaultAddr, VaultToken, VaultVersion string
+	CustomLocalForward, EnvSSHUsername, EnvVaultAddr, NameSpace, SecretPath, Show, StoragePath, User, VaultAddr, VaultToken, VaultVersion string
 }
 
 var (
@@ -91,6 +91,7 @@ func GetConfig() *Settings {
 			EnvSSHUsername:        EnvSSHUsername,
 			EnvVaultAddr:          EnvVaultAddr,
 			LogLevel:              logrus.WarnLevel,
+			NameSpace:             "",
 			SecretPath:            SecretPath,
 			Simulate:              false,
 			StoragePath:           EnvBasePath,

--- a/log/logger.go
+++ b/log/logger.go
@@ -116,7 +116,7 @@ func getInstance(level logrus.Level, logFile string) (*logrus.Logger, error) {
 	logrus.SetLevel(level)
 
 	userLogger := logrus.New()
-	//userLogger.SetReportCaller(true)
+	// userLogger.SetReportCaller(true)
 	userLogger.SetFormatter(&logrus.TextFormatter{
 		DisableColors:          true,
 		DisableLevelTruncation: true,
@@ -126,7 +126,7 @@ func getInstance(level logrus.Level, logFile string) (*logrus.Logger, error) {
 		},*/
 	})
 	if logFile != "" {
-		file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+		file, err := os.OpenFile(logFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 		defer file.Close()
 
 		if err == nil {

--- a/scripts/dev-vault.sh
+++ b/scripts/dev-vault.sh
@@ -38,6 +38,8 @@ function prepare_vault {
     vault login -no-store
     vault secrets disable secret/
     vault secrets enable --path=secret/ssh_ms kv
+    vault secrets enable --path=moresecret/ssh_ms kv
+    vault secrets enable --path=secret/ssh_ms_admin kv
 
     ./bin/ssh_ms write test --comment Testing HostName=localhost User=@@USER_FIRSTNAME
 }
@@ -49,6 +51,16 @@ path "sys/*" {
 }
 
 path "secret/ssh_ms/*" {
+  policy = "read"
+  capabilities = ["list", "sudo"]
+}
+
+path "moresecret/ssh_ms/*" {
+  policy = "read"
+  capabilities = ["list", "sudo"]
+}
+
+path "secret/ssh_ms_admin/*" {
   policy = "read"
   capabilities = ["list", "sudo"]
 }

--- a/ssh/main.go
+++ b/ssh/main.go
@@ -75,9 +75,9 @@ type Connection struct {
 	Cache               CachedConnection
 	ControlPath         string
 	ForwardAgent        string
-	//Compression bool
-	//ControlMaster bool
-	//ControlPersist uint16
+	// Compression bool
+	// ControlMaster bool
+	// ControlPersist uint16
 }
 
 // CachedConnection contains a full config
@@ -122,7 +122,6 @@ func (c Connection) exists(lf LocalForward) bool {
 // doMarshal of userName to JSON format
 func (un *userName) doMarshal() (string, error) {
 	data, err := json.Marshal(un)
-
 	if err != nil {
 		log.Error("Failed to marshal:", un, ", error:", err)
 		return "", err
@@ -136,7 +135,6 @@ func (un *userName) doUnmarshal(jsonString string) (userName, error) {
 	var newUser userName
 
 	err := json.Unmarshal([]byte(jsonString), &newUser)
-
 	if err != nil {
 		log.Error("Failed to unmarshal:", jsonString, ", error: ", err)
 		return userName{}, err
@@ -150,7 +148,6 @@ func (un *userName) doUnmarshalToKeys(jsonString string) (map[string]interface{}
 	var keyedItem map[string]interface{}
 
 	err := json.Unmarshal([]byte(jsonString), &keyedItem)
-
 	if err != nil {
 		log.Error("Failed to unmarshal:", jsonString, ", error: ", err)
 		return nil, err
@@ -193,7 +190,7 @@ func (un *userName) generateUserName(username string) (bool, error) {
 // rewriteUsername config templates
 func (un *userName) rewriteUsername(newuser string) (bool, error) {
 	var b bytes.Buffer
-	var tempUser = userName{}
+	tempUser := userName{}
 	tempUser.generateUserName(newuser)
 	log.Debugf("original user '%v'", un)
 
@@ -443,7 +440,7 @@ func setPortForwarding(sshArgs *Connection) {
 		log.Errorf("Failed to generate JSON to cache '%v': %v", sshArgs.ControlPath, err)
 	}
 
-	if err := ioutil.WriteFile(sshArgs.ControlPath+".json", []byte(string(buff)), 0640); err != nil {
+	if err := ioutil.WriteFile(sshArgs.ControlPath+".json", []byte(string(buff)), 0o640); err != nil {
 		log.Errorf("Failed to save cache for '%v': %v", sshArgs.ControlPath, err)
 	}
 }

--- a/ssh/main_test.go
+++ b/ssh/main_test.go
@@ -64,7 +64,6 @@ func TestMarshal(t *testing.T) {
 		newUser, err := user.doUnmarshal(jsonUser)
 		if err != nil {
 			t.Fatalf("expected: %v as userName got: %v with error %v", jsonUser, newUser, err)
-
 		}
 
 		if user.FullName != newUser.FullName {
@@ -97,7 +96,7 @@ func TestControlPath(t *testing.T) {
 	expected := fmt.Sprintf("cp_%s_%s_%d", conn.User, conn.HostName, conn.Port)
 	rawCp := fmt.Sprintf("%s/%s", cfg.StoragePath, expected)
 
-	if err := ioutil.WriteFile(rawCp, []byte("dummy"), 0640); err != nil {
+	if err := ioutil.WriteFile(rawCp, []byte("dummy"), 0o640); err != nil {
 		t.Fatalf("expected: a dummy file to be created, got: %v", err)
 	}
 
@@ -159,7 +158,7 @@ func TestConnection(t *testing.T) {
 	}
 
 	// Test loading custom LocalForward ports from cache
-	if err := ioutil.WriteFile(conn.ControlPath, []byte(""), 0600); err != nil {
+	if err := ioutil.WriteFile(conn.ControlPath, []byte(""), 0o600); err != nil {
 		t.Fatal("failed to write dummy ControlPath:", conn.ControlPath, err)
 	}
 	setPortForwarding(&conn)

--- a/templates/policy-full.sh
+++ b/templates/policy-full.sh
@@ -1,0 +1,18 @@
+path "sys/*" {
+  policy = "deny"
+}
+
+path "secret/ssh_ms/*" {
+  policy = "read"
+  capabilities = ["list", "sudo"]
+}
+
+path "moresecret/ssh_ms/*" {
+  policy = "read"
+  capabilities = ["list", "sudo"]
+}
+
+path "secret/ssh_ms_admin/*" {
+  policy = "read"
+  capabilities = ["list", "sudo"]
+}

--- a/templates/policy-min.sh
+++ b/templates/policy-min.sh
@@ -4,5 +4,5 @@ path "sys/*" {
 
 path "secret/ssh_ms/*" {
   policy = "read"
-  capabilities = ["list", "sudo"]
+  capabilities = ["create", "read", "update", "patch", "delete", "list"]
 }

--- a/templates/policy-min.sh
+++ b/templates/policy-min.sh
@@ -1,0 +1,8 @@
+path "sys/*" {
+  policy = "deny"
+}
+
+path "secret/ssh_ms/*" {
+  policy = "read"
+  capabilities = ["list", "sudo"]
+}

--- a/vault/helper.go
+++ b/vault/helper.go
@@ -109,7 +109,7 @@ func ListSecrets(c *api.Client, path string) ([]*api.Secret, []error) {
 	}
 
 	if len(errors) > 0 {
-		return nil, errors
+		return secrets, errors
 	}
 
 	return secrets, nil

--- a/vault/helper.go
+++ b/vault/helper.go
@@ -94,12 +94,25 @@ func DeleteSecret(c *api.Client, key string) (bool, error) {
 // ListSecrets reads the list of secrets/data under a path in Vault
 // c : Vault client
 // path : path to secret/data in Vault
-func ListSecrets(c *api.Client, path string) (*api.Secret, error) {
-	secret, err := c.Logical().List(path)
-	if err != nil {
-		return nil, err
+func ListSecrets(c *api.Client, path string) ([]*api.Secret, []error) {
+	errors := []error{}
+	paths := strings.Split(path, ",")
+	secrets := []*api.Secret{}
+
+	for _, p := range paths {
+		secret, err := c.Logical().List(p)
+		if err != nil {
+			errors = append(errors, err)
+		} else {
+			secrets = append(secrets, secret)
+		}
 	}
-	return secret, nil
+
+	if len(errors) > 0 {
+		return nil, errors
+	}
+
+	return secrets, nil
 }
 
 // ReadSecret requests the secret/data from Vault

--- a/vault/helper_test.go
+++ b/vault/helper_test.go
@@ -87,14 +87,15 @@ func TestHelpers(t *testing.T) {
 	expires := time.Now().Add(24 * time.Hour)
 	if !requiresRenewal(map[string]interface{}{
 		"renewable":   true,
-		"expire_time": expires.Format(time.RFC3339)}) {
+		"expire_time": expires.Format(time.RFC3339),
+	}) {
 		t.Fatalf(("requiresRenewal expected: true"))
 	}
 	expires = expires.Add(24 * 8 * time.Hour)
 	if requiresRenewal(map[string]interface{}{
 		"renewable":   true,
-		"expire_time": expires.Format(time.RFC3339)}) {
+		"expire_time": expires.Format(time.RFC3339),
+	}) {
 		t.Fatalf(("requiresRenewal expected: false"))
 	}
-
 }


### PR DESCRIPTION
By adding support for multiple namespaces, it is possible to provide
access control for larger groups where a single namespace either
becomes too verbose, or simply allows visibility to information that
would be hidden by preference. Using different Vault policies will
allow both of these to be addressed.
    
* Added `--namespace` option to allow for filtering when multiple
  namespaces are available to the user, adding
  `config.Settings.NameSpace` to store it at runtime.
* Updated `cmd.getVersion` to display the configured `SecretPath`
   items in verbose mode
* Added `cmd.getSecretPath` to iterate namespaces and updated
   references to call it in place of using `cfg.SecretPath`
* Updated `cmd.getConnections` to accept a slice of secrets
* Updated `vault.ListSecrets` to iterate over the available
   namespaces, returning a slice of secrets instead of a single
   secret
* Updated `vault.ListSecret` to return secrets _and_ errors when
   an error exists, allowing a check on number of secrets
* Updated `cmd.getConnections` to check the number of secrets when
   listing
* Tweaked dev-vault bootstrap
* Minor formatting & linting
    
Resolves #83