### PR TITLE
Optional renewal warning

### DIFF
--- a/vault/helper.go
+++ b/vault/helper.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/vault/api"
 
+	"github.com/cezmunsta/ssh_ms/config"
 	"github.com/cezmunsta/ssh_ms/log"
 )
 
@@ -21,8 +22,12 @@ type UserEnv struct {
 	Simulate    bool
 }
 
-// RenewThreshold is used to compare against the token expiration time
-var RenewThreshold = "168h"
+var (
+	cfg = config.GetConfig()
+
+	// RenewThreshold is used to compare against the token expiration time
+	RenewThreshold = "168h"
+)
 
 const (
 	apiTimeout           = time.Second * 60
@@ -77,6 +82,10 @@ func Authenticate(e UserEnv, st bool) *api.Client {
 
 func requiresRenewal(d map[string]interface{}) bool {
 	log.Debugf("Checking data: %v", d)
+	if cfg.RenewWarningOptOut {
+		log.Debug("Bypassing renewal check")
+		return false
+	}
 	if val, ok := d["renewable"]; ok && !val.(bool) {
 		return false
 	}

--- a/vault/helper_test.go
+++ b/vault/helper_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cezmunsta/ssh_ms/config"
 	vaultKv "github.com/hashicorp/vault-plugin-secrets-kv"
 	vaultApi "github.com/hashicorp/vault/api"
 	vaultHttp "github.com/hashicorp/vault/http"
@@ -16,7 +15,6 @@ import (
 )
 
 var (
-	cfg              = config.GetConfig()
 	client           *vaultApi.Client
 	cluster          *vault.TestCluster
 	once             sync.Once
@@ -101,6 +99,15 @@ func TestHelpers(t *testing.T) {
 	}
 
 	expires = expires.Add(24 * 8 * time.Hour)
+	if requiresRenewal(map[string]interface{}{
+		"renewable":   true,
+		"expire_time": expires.Format(time.RFC3339),
+	}) {
+		t.Fatalf("requiresRenewal expected: false")
+	}
+
+	expires = time.Now().Add(-time.Hour)
+	cfg.RenewWarningOptOut = true
 	if requiresRenewal(map[string]interface{}{
 		"renewable":   true,
 		"expire_time": expires.Format(time.RFC3339),


### PR DESCRIPTION
When a user's token is close to expiring, as determined by the renew threshold, a warning message is emitted. Whilst this is useful in most cases, when a token has a short ttl the message is relatively meaningless.

* Added functionality to allow the user to decide whether or not they wish to receive the warning message. By setting an environment variable, `SSH_MS_RENEW_WARNING_OPTOUT`, the user can disable the message; accepted values are: "1", "true", or "yes"