### PR TITLE
Speedup for tests by reducing to a single Vault node

### DIFF
--- a/helpers/cluster.go
+++ b/helpers/cluster.go
@@ -43,9 +43,12 @@ func GetDummyCluster(t *testing.T) (*docker.DockerCluster, *vaultApi.Client) {
 
 		defer cancel()
 
+		clusterOpts := docker.DefaultOptions(t)
+		clusterOpts.ClusterOptions.NumCores = 1
 		opts := &docker.DockerClusterOptions{
-			ImageRepo: "hashicorp/vault",
-			ImageTag:  "latest",
+			ImageRepo:      "hashicorp/vault",
+			ImageTag:       "latest",
+			ClusterOptions: clusterOpts.ClusterOptions,
 		}
 		cluster = docker.NewTestDockerCluster(t, opts)
 


### PR DESCRIPTION
To help reduce the amount of time use during unit tests, the cluster size can be reduced down to a single node.

* Updated `helpers.GetDummyCluster` to change the `NumCores` of the cluster from 1 to 3