### PR TITLE
Updated PR workflow Go version

### DIFF
--- a/.github/workflows/pr-go.yaml
+++ b/.github/workflows/pr-go.yaml
@@ -37,8 +37,8 @@ jobs:
       - name: Prepare Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: '1.21'
-          check_latest: true
+          go-version: '1.21.5'
+          check_latest: false
 
       - name: Checkout codebase
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
* Updated workflow to set go-version to  1.21.5 and check_latest to false
