### PR TITLE
Replace static VPN deny-list with baseline-delta detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ debug
 old
 patches
 vendor
+CLAUDE.md

--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,15 @@ SSH_MS_SECRET_PATH?=secret/ssh_ms
 SSH_MS_SYNC_HOST?=localhost
 SSH_MS_SYNC_PATH?=/usr/share/nginx/html/downloads/ssh_ms/
 SSH_MS_USERNAME?=SSH_MS_USERNAME
-SSH_MS_VPN_CHECK_NAMES?=
 
 DEBUG_BUILD=$(shell test "${DEBUG}" = "1" && echo 1 || echo 0)
 COMPRESS_BINARY=$(shell test "${XZ_COMPRESS}" = "1" && echo 1 || echo 0)
 
 PACKAGE=github.com/cezmunsta/ssh_ms
 ifeq ($(DEBUG_BUILD), 1)
-LDFLAGS=-ldflags "-X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR} -X ${PACKAGE}/config.SecretPath=${SSH_MS_SECRET_PATH} -X ${PACKAGE}/vault.RenewThreshold=${SSH_MS_RENEW_THRESHOLD} -X ${PACKAGE}/config.portServiceMappings=${SSH_MS_SECRET_MAP} -X ${PACKAGE}/config.undesiredInterfaces=${SSH_MS_VPN_CHECK_NAMES}"
+LDFLAGS=-ldflags "-X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR} -X ${PACKAGE}/config.SecretPath=${SSH_MS_SECRET_PATH} -X ${PACKAGE}/vault.RenewThreshold=${SSH_MS_RENEW_THRESHOLD} -X ${PACKAGE}/config.portServiceMappings=${SSH_MS_SECRET_MAP}"
 else
-LDFLAGS=-ldflags "-w -X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR} -X ${PACKAGE}/config.SecretPath=${SSH_MS_SECRET_PATH} -X ${PACKAGE}/vault.RenewThreshold=${SSH_MS_RENEW_THRESHOLD} -X ${PACKAGE}/config.portServiceMappings=${SSH_MS_SECRET_MAP} -X ${PACKAGE}/config.undesiredInterfaces=${SSH_MS_VPN_CHECK_NAMES}"
+LDFLAGS=-ldflags "-w -X ${PACKAGE}/config.EnvBasePath=${SSH_MS_BASEPATH} -X ${PACKAGE}/cmd.Version=${RELEASE_VER} -X ${PACKAGE}/config.EnvSSHUsername=${SSH_MS_USERNAME} -X ${PACKAGE}/config.EnvSSHIdentityFile=${SSH_MS_ID_FILE} -X ${PACKAGE}/config.EnvSSHDefaultUsername=${SSH_MS_DEFAULT_USERNAME} -X ${PACKAGE}/config.EnvVaultAddr=${SSH_MS_DEFAULT_VAULT_ADDR} -X ${PACKAGE}/config.SecretPath=${SSH_MS_SECRET_PATH} -X ${PACKAGE}/vault.RenewThreshold=${SSH_MS_RENEW_THRESHOLD} -X ${PACKAGE}/config.portServiceMappings=${SSH_MS_SECRET_MAP}"
 endif
 
 VETFLAGS?=( -unusedresult -bools -copylocks -framepointer -httpresponse -json -stdmethods -printf -stringintconv -unmarshal -unsafeptr )

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -195,6 +195,11 @@ func init() {
 		populateCacheCmd,
 		purgeCacheCmd,
 	)
+	vpnBaselineCmd.AddCommand(
+		vpnBaselineCaptureCmd,
+		vpnBaselineResetCmd,
+		vpnBaselineShowCmd,
+	)
 	rootCmd.AddCommand(
 		cacheCmd,
 		connectCmd,
@@ -206,6 +211,7 @@ func init() {
 		showCmd,
 		versionCmd,
 		updateCmd,
+		vpnBaselineCmd,
 		writeCmd,
 	)
 	rootCmd.PersistentFlags().StringVar(&cfg.VaultAddr, "vault-addr", cfg.EnvVaultAddr, "Specify the Vault address")
@@ -222,6 +228,8 @@ func init() {
 
 	connectCmd.Flags().StringVarP(&cfg.CustomLocalForward, "local-forward", "l", "",
 		"Define adhoc LocalForward rules by specifying the target ports, e.g. -l 8080,3306")
+	connectCmd.Flags().BoolVar(&cfg.CheckVPN, "check-vpn", true,
+		"Compare current network interfaces against the captured baseline and prompt if new VPN-like interfaces appear")
 
 	purgeCacheCmd.Flags().BoolVarP(&purgeForce, "force", "f", false, "Bypass confirmation prompt")
 	purgeCacheCmd.Flags().StringVarP(&purgeConnection, "connection", "c", "", "Select a connection to purge")

--- a/cmd/vpn.go
+++ b/cmd/vpn.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cezmunsta/ssh_ms/log"
+	"github.com/cezmunsta/ssh_ms/ssh"
+)
+
+var (
+	vpnBaselineCmd = &cobra.Command{
+		Use:   "vpn-baseline",
+		Short: "Manage the VPN interface baseline",
+		Long: "Manage the network-interface snapshot used to detect new VPN tunnels " +
+			"before connecting. Use `capture` while disconnected from any VPN, `show` " +
+			"to inspect the stored snapshot, and `reset` to clear it.",
+	}
+
+	vpnBaselineCaptureCmd = &cobra.Command{
+		Use:   "capture",
+		Short: "Capture the current network interfaces as the safe baseline",
+		Long: "Snapshots the currently configured network interfaces and stores them as the baseline. " +
+			"Run this while you are NOT connected to any VPN.",
+		Run: func(cmd *cobra.Command, args []string) {
+			b, err := ssh.CaptureBaseline(cfg.VPNBaselinePath)
+			if err != nil {
+				log.Fatalf("failed to capture baseline: %v", err)
+			}
+			fmt.Printf("Baseline captured at %s\n", cfg.VPNBaselinePath)
+			fmt.Printf("Interfaces (%d): %v\n", len(b.Interfaces), b.Interfaces)
+		},
+	}
+
+	vpnBaselineResetCmd = &cobra.Command{
+		Use:   "reset",
+		Short: "Remove the stored baseline",
+		Long:  "Deletes the baseline snapshot. The next `connect` will prompt to capture a new one.",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := ssh.ResetBaseline(cfg.VPNBaselinePath); err != nil {
+				log.Fatalf("failed to reset baseline: %v", err)
+			}
+			fmt.Printf("Baseline removed: %s\n", cfg.VPNBaselinePath)
+		},
+	}
+
+	vpnBaselineShowCmd = &cobra.Command{
+		Use:   "show",
+		Short: "Display the stored baseline",
+		Run: func(cmd *cobra.Command, args []string) {
+			b, err := ssh.LoadBaseline(cfg.VPNBaselinePath)
+			if errors.Is(err, ssh.ErrNoBaseline) {
+				fmt.Printf("No baseline stored at %s\n", cfg.VPNBaselinePath)
+				return
+			}
+			if err != nil {
+				log.Fatalf("failed to load baseline: %v", err)
+			}
+			fmt.Printf("Captured at: %s\n", b.CapturedAt.Format("2006-01-02 15:04:05 MST"))
+			fmt.Printf("Hostname:    %s\n", b.Hostname)
+			fmt.Printf("Interfaces (%d):\n", len(b.Interfaces))
+			for _, name := range b.Interfaces {
+				fmt.Printf("  - %s\n", name)
+			}
+		},
+	}
+)

--- a/config/main.go
+++ b/config/main.go
@@ -14,12 +14,12 @@ import (
 
 // Settings contains the configuration details
 type Settings struct {
-	LogLevel                                                                         logrus.Level
-	Debug, RenewWarningOptOut, Simulate, StoredToken, Verbose, Version, VersionCheck bool
+	LogLevel                                                                                   logrus.Level
+	CheckVPN, Debug, RenewWarningOptOut, Simulate, StoredToken, Verbose, Version, VersionCheck bool
 	ConfigComment, ConfigMotd, EnvSSHDefaultUsername, EnvSSHIdentityFile,
-	CustomLocalForward, EnvSSHUsername, EnvVaultAddr, NameSpace, SecretPath, Show, StoragePath, User, VaultAddr, VaultToken, VaultAPIVersion, VaultSDKVersion string
-	ServiceMap          map[string]string
-	UndesiredInterfaces []string
+	CustomLocalForward, EnvSSHUsername, EnvVaultAddr, NameSpace, SecretPath, Show, StoragePath, User, VaultAddr, VaultToken, VaultAPIVersion, VaultSDKVersion, VPNBaselinePath string
+	ServiceMap  map[string]string
+	VPNPatterns []string
 }
 
 var (
@@ -52,11 +52,19 @@ var (
 	// SecretPath is the location used for connection manangement
 	SecretPath = "secret/ssh_ms"
 
-	portServiceMappings string
-	undesiredInterfaces string
+	// VPNBaselineFile is the filename (within StoragePath) used for the
+	// captured network-interface baseline used to detect new VPN tunnels.
+	VPNBaselineFile = "vpn_baseline.json"
 
-	serviceMap              = make(map[string]string)
-	undesiredInterfaceNames = []string{}
+	// DefaultVPNPatterns are regex patterns matching VPN-like interface
+	// names. Newly observed interfaces matching any of these (and not on
+	// the whitelist) trigger a confirmation prompt before connect.
+	DefaultVPNPatterns = []string{`^tun`, `^utun`, `^ppp`, `^tap`, `^wg`, `^ipsec`}
+
+	portServiceMappings string
+
+	serviceMap  = make(map[string]string)
+	vpnPatterns = []string{}
 )
 
 func init() {
@@ -80,14 +88,21 @@ func init() {
 		}
 	}
 
-	userByPass := os.Getenv("SSH_MS_BYPASS_INTERFACE_CHECK")
-	if userByPass == "1" || userByPass == "yes" || userByPass == "true" {
-		undesiredInterfaces = ""
+	vpnPatterns = append(vpnPatterns, DefaultVPNPatterns...)
+	if v := os.Getenv("SSH_MS_VPN_PATTERNS"); v != "" {
+		vpnPatterns = splitCSV(v)
 	}
+}
 
-	if len(undesiredInterfaces) > 0 {
-		undesiredInterfaceNames = strings.Split(undesiredInterfaces, ",")
+func splitCSV(v string) []string {
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
 	}
+	return out
 }
 
 // ToJSON returns the config in JSON format
@@ -129,6 +144,7 @@ func GetConfig() *Settings {
 		}
 
 		settings = Settings{
+			CheckVPN:              true,
 			ConfigComment:         "",
 			ConfigMotd:            "",
 			CustomLocalForward:    "",
@@ -144,9 +160,10 @@ func GetConfig() *Settings {
 			Simulate:              false,
 			StoragePath:           EnvBasePath,
 			StoredToken:           false,
-			UndesiredInterfaces:   undesiredInterfaceNames,
 			VaultAPIVersion:       vaultAPIVersion,
 			VaultSDKVersion:       vaultSDKVersion,
+			VPNBaselinePath:       filepath.Join(EnvBasePath, VPNBaselineFile),
+			VPNPatterns:           vpnPatterns,
 		}
 	})
 	return &settings

--- a/config/versions.go
+++ b/config/versions.go
@@ -2,6 +2,6 @@
 package config
 
 const (
-	vaultAPIVersion = "v1.22.0"
-	vaultSDKVersion = "v0.23.0"
+	vaultAPIVersion = "v1.23.0"
+	vaultSDKVersion = "v0.25.0"
 )

--- a/ssh/main.go
+++ b/ssh/main.go
@@ -1,20 +1,17 @@
 package ssh
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/sha1"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"maps"
 	"net"
 	"os"
 	"os/exec"
 	"reflect"
-	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -112,67 +109,6 @@ func acquirePort(min uint16, max uint16) (uint16, error) {
 		return i, nil
 	}
 	return 0, errNoFreePort
-}
-
-// check network interfaces
-func checkNetworkInterfaces(denyList []string) ([]string, error) {
-	var blockedInterfaces []string
-	var regexPatterns []*regexp.Regexp
-
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get network interfaces: %w", err)
-	}
-
-	for _, pattern := range denyList {
-		re, err := regexp.Compile(pattern)
-		if err != nil {
-			return nil, fmt.Errorf("invalid regex pattern '%s': %w", pattern, err)
-		}
-		regexPatterns = append(regexPatterns, re)
-	}
-
-	for _, iface := range interfaces {
-		allowed := false
-		for _, re := range regexPatterns {
-			if !re.MatchString(iface.Name) {
-				allowed = true
-				break
-			}
-		}
-		if !allowed {
-			blockedInterfaces = append(blockedInterfaces, iface.Name)
-		}
-	}
-
-	return blockedInterfaces, nil
-}
-
-// action for when undesired network interfaces are required
-func handleUndesiredInterfacePresent() {
-	fmt.Println("Please confirm that you wish to proceed? y/n")
-
-	reader := bufio.NewReader(os.Stdin)
-	answer, err := reader.ReadString('\n')
-	if err != nil {
-		if err == io.EOF {
-			fmt.Println("\nInput cancelled")
-			os.Exit(1)
-		}
-		fmt.Fprintf(os.Stderr, "Error reading input: %v\n", err)
-		os.Exit(1)
-	}
-
-	switch strings.ToLower(strings.TrimSpace(answer)) {
-	case "y", "yes", "1":
-		fmt.Println("Proceeding...")
-	case "n", "no", "0":
-		fmt.Println("Cancelled")
-		os.Exit(0)
-	default:
-		fmt.Println("Invalid input. Please enter y/n")
-		os.Exit(1)
-	}
 }
 
 // exists checks to see if a value is already present
@@ -605,13 +541,11 @@ func Connect(args []string, e UserEnv) {
 	if e.Simulate {
 		log.Println("cmd: ssh", strings.Join(args, " "))
 	} else {
-		if len(cfg.UndesiredInterfaces) > 0 {
-			log.Debug("Interface check enabled, checking before connecting")
-
-			if detectedInterfaces, err := checkNetworkInterfaces(cfg.UndesiredInterfaces); err != nil || len(detectedInterfaces) > 0 {
-				log.Warningf("detected undesired interfaces: %v", detectedInterfaces)
-				fmt.Println("Your data may be transferred through undesired interfaces:", detectedInterfaces)
-				handleUndesiredInterfacePresent()
+		if cfg.CheckVPN {
+			log.Debug("VPN baseline check enabled")
+			if !EnforceBaseline(cfg.VPNBaselinePath, cfg.VPNPatterns) {
+				log.Debug("connection aborted by user (VPN baseline)")
+				return
 			}
 		}
 

--- a/ssh/vpn.go
+++ b/ssh/vpn.go
@@ -1,0 +1,258 @@
+package ssh
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cezmunsta/ssh_ms/log"
+)
+
+// Baseline is the persisted snapshot of network-interface names captured
+// while the user has confirmed they are disconnected from any VPN. New
+// interfaces appearing after this baseline (and matching the VPN pattern
+// list) trigger a confirmation prompt before connect.
+type Baseline struct {
+	CapturedAt time.Time `json:"captured_at"`
+	Hostname   string    `json:"hostname"`
+	Interfaces []string  `json:"interfaces"`
+}
+
+// ErrNoBaseline is returned by LoadBaseline when no snapshot exists.
+var ErrNoBaseline = errors.New("no baseline snapshot found")
+
+// currentInterfaces returns the names of all currently configured
+// network interfaces, sorted for deterministic comparisons.
+func currentInterfaces() ([]string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list interfaces: %w", err)
+	}
+	names := make([]string, 0, len(ifaces))
+	for _, i := range ifaces {
+		names = append(names, i.Name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// LoadBaseline reads the baseline snapshot from path. Returns
+// ErrNoBaseline when the file does not exist.
+func LoadBaseline(path string) (*Baseline, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNoBaseline
+		}
+		return nil, fmt.Errorf("failed to read baseline %s: %w", path, err)
+	}
+	var b Baseline
+	if err := json.Unmarshal(data, &b); err != nil {
+		return nil, fmt.Errorf("failed to parse baseline %s: %w", path, err)
+	}
+	return &b, nil
+}
+
+// SaveBaseline persists the snapshot to path with 0600 permissions.
+func SaveBaseline(path string, b *Baseline) error {
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal baseline: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("failed to write baseline %s: %w", path, err)
+	}
+	return nil
+}
+
+// ResetBaseline removes the baseline file. Returns nil if the file does
+// not exist.
+func ResetBaseline(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// CaptureBaseline snapshots the current network interfaces and writes
+// the result to path. The returned Baseline is the value just written.
+func CaptureBaseline(path string) (*Baseline, error) {
+	names, err := currentInterfaces()
+	if err != nil {
+		return nil, err
+	}
+	host, _ := os.Hostname()
+	b := &Baseline{
+		CapturedAt: time.Now().UTC(),
+		Hostname:   host,
+		Interfaces: names,
+	}
+	if err := SaveBaseline(path, b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+// matchAny returns true if name matches any of the regex patterns.
+// Patterns that fail to compile are skipped with a warning.
+func matchAny(name string, patterns []string) bool {
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			log.Warningf("invalid regex pattern %q: %v", p, err)
+			continue
+		}
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// DiffInterfaces returns the names of interfaces in current that are not
+// present in baseline and match at least one of vpnPatterns. The
+// baseline doubles as the trust list — to permanently whitelist an
+// interface, capture a fresh baseline that includes it. The result is
+// sorted.
+func DiffInterfaces(current, baseline, vpnPatterns []string) []string {
+	known := make(map[string]struct{}, len(baseline))
+	for _, n := range baseline {
+		known[n] = struct{}{}
+	}
+
+	var out []string
+	for _, name := range current {
+		if _, seen := known[name]; seen {
+			continue
+		}
+		if !matchAny(name, vpnPatterns) {
+			continue
+		}
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// promptYesNo asks the user for confirmation on stdin. Returns true on
+// y/yes/1, false on n/no/0. EOF or unrecognised input returns false.
+func promptYesNo(question string) bool {
+	fmt.Printf("%s (y/n) ", question)
+	reader := bufio.NewReader(os.Stdin)
+	answer, err := reader.ReadString('\n')
+	if err != nil {
+		if err == io.EOF {
+			fmt.Println()
+		} else {
+			fmt.Fprintf(os.Stderr, "error reading input: %v\n", err)
+		}
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(answer)) {
+	case "y", "yes", "1":
+		return true
+	default:
+		return false
+	}
+}
+
+// EnforceBaseline runs the baseline-aware VPN check. If no snapshot
+// exists, it prompts the user to confirm they are VPN-disconnected and
+// captures one on a positive answer. If a snapshot exists, it computes
+// the delta of VPN-like interfaces and prompts before continuing.
+//
+// Returns true when it is safe to continue with the connection. False
+// indicates the user declined or input could not be read.
+func EnforceBaseline(baselinePath string, vpnPatterns []string) bool {
+	current, err := currentInterfaces()
+	if err != nil {
+		log.Warningf("VPN baseline check skipped: %v", err)
+		return true
+	}
+
+	baseline, err := LoadBaseline(baselinePath)
+	if errors.Is(err, ErrNoBaseline) {
+		fmt.Println()
+		fmt.Println("==================== VPN baseline setup ====================")
+		fmt.Println("No baseline of your network interfaces is on file yet.")
+		fmt.Println()
+		fmt.Println("ssh_ms uses this baseline to detect new VPN tunnels (tun/utun/")
+		fmt.Println("ppp/tap/wg/ipsec) that appear after the snapshot. The goal is to")
+		fmt.Println("prevent connecting to a sensitive customer host while another")
+		fmt.Println("customer's VPN is active — that has caused security incidents in")
+		fmt.Println("the past because traffic can be tunneled through the wrong network.")
+		fmt.Println()
+		fmt.Println("Before capturing the baseline, please make sure that ALL customer")
+		fmt.Println("VPNs are disconnected. Trusted always-on interfaces (corporate")
+		fmt.Println("VPN, Tailscale, etc.) will be included in the snapshot and never")
+		fmt.Println("flagged again. To trust a new VPN later, simply re-capture the")
+		fmt.Println("baseline while that VPN is connected and nothing else is.")
+		fmt.Println()
+		fmt.Println("Baseline commands:")
+		fmt.Println("  ssh_ms vpn-baseline capture   # snapshot current interfaces")
+		fmt.Println("  ssh_ms vpn-baseline reset     # forget the baseline")
+		fmt.Println("  ssh_ms vpn-baseline show      # display the stored snapshot")
+		fmt.Println("============================================================")
+		fmt.Println()
+		if !promptYesNo("Are you currently disconnected from every customer VPN?") {
+			fmt.Println()
+			fmt.Println("Connection aborted. Disconnect from your VPN first, then either")
+			fmt.Println("re-run this command or capture the baseline manually with:")
+			fmt.Println("  ssh_ms vpn-baseline capture")
+			return false
+		}
+		b, err := CaptureBaseline(baselinePath)
+		if err != nil {
+			log.Warningf("failed to capture baseline: %v", err)
+			return false
+		}
+		fmt.Println()
+		fmt.Printf("Baseline captured (%d interfaces) at:\n  %s\n", len(b.Interfaces), baselinePath)
+		fmt.Println("Future connects will warn if new VPN-like interfaces appear.")
+		fmt.Println()
+		return true
+	}
+	if err != nil {
+		log.Warningf("baseline check failed: %v", err)
+		return true
+	}
+
+	delta := DiffInterfaces(current, baseline.Interfaces, vpnPatterns)
+	if len(delta) == 0 {
+		return true
+	}
+
+	fmt.Println()
+	fmt.Println("==================== VPN safety check ======================")
+	fmt.Println("New VPN-like network interfaces detected since baseline:")
+	for _, name := range delta {
+		fmt.Printf("  - %s\n", name)
+	}
+	fmt.Println()
+	fmt.Println("This usually means a VPN client connected after your baseline was")
+	fmt.Println("captured. If the VPN you're on belongs to a DIFFERENT customer than")
+	fmt.Println("the host you're about to reach, your SSH traffic can be tunneled")
+	fmt.Println("through the wrong customer's network — this is a known cause of")
+	fmt.Println("cross-customer routing incidents.")
+	fmt.Println()
+	fmt.Println("Proceed only if you've verified that the active VPN matches the")
+	fmt.Println("customer this host belongs to.")
+	fmt.Println()
+	fmt.Println("If this VPN is something you want ssh_ms to trust from now on")
+	fmt.Println("(e.g. a corporate always-on VPN you just installed), connect ONLY")
+	fmt.Println("to that VPN and re-capture the baseline:")
+	fmt.Println("  ssh_ms vpn-baseline capture")
+	fmt.Println()
+	fmt.Println("To skip this check for one run, re-run with --check-vpn=false.")
+	fmt.Println("============================================================")
+	fmt.Println()
+	return promptYesNo("Proceed with the connection?")
+}

--- a/ssh/vpn_test.go
+++ b/ssh/vpn_test.go
@@ -1,0 +1,130 @@
+package ssh
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestDiffInterfaces(t *testing.T) {
+	patterns := []string{`^tun`, `^utun`, `^ppp`, `^tap`, `^wg`, `^ipsec`}
+
+	cases := []struct {
+		name     string
+		current  []string
+		baseline []string
+		want     []string
+	}{
+		{
+			name:     "no new interfaces",
+			current:  []string{"lo0", "en0", "utun0", "utun1"},
+			baseline: []string{"lo0", "en0", "utun0", "utun1"},
+			want:     nil,
+		},
+		{
+			name:     "ignores non-vpn-like new interfaces (gif, stf)",
+			current:  []string{"lo0", "en0", "gif0", "stf0", "utun0"},
+			baseline: []string{"lo0", "en0", "utun0"},
+			want:     nil,
+		},
+		{
+			name:     "new utun interface flagged",
+			current:  []string{"lo0", "en0", "utun0", "utun12"},
+			baseline: []string{"lo0", "en0", "utun0"},
+			want:     []string{"utun12"},
+		},
+		{
+			name:     "new wireguard and tun both flagged",
+			current:  []string{"lo0", "en0", "tun0", "wg0"},
+			baseline: []string{"lo0", "en0"},
+			want:     []string{"tun0", "wg0"},
+		},
+		{
+			name:     "baseline as trust list suppresses match",
+			current:  []string{"lo0", "en0", "tailscale0", "utun9"},
+			baseline: []string{"lo0", "en0", "tailscale0", "utun9"},
+			want:     nil,
+		},
+		{
+			name:     "interfaces sharing VPN-like prefix still flagged when missing from baseline",
+			current:  []string{"lo0", "en0", "wg-corp", "wg-vpn"},
+			baseline: []string{"lo0", "en0"},
+			want:     []string{"wg-corp", "wg-vpn"},
+		},
+		{
+			name:     "all baselined utuns ignored",
+			current:  []string{"lo0", "en0", "utun0", "utun1", "utun2"},
+			baseline: []string{"lo0", "en0", "utun0", "utun1", "utun2"},
+			want:     nil,
+		},
+		{
+			name:     "empty baseline flags every VPN-like iface",
+			current:  []string{"lo0", "en0", "utun0", "tap0"},
+			baseline: nil,
+			want:     []string{"tap0", "utun0"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DiffInterfaces(tc.current, tc.baseline, patterns)
+			want := append([]string{}, tc.want...)
+			sort.Strings(want)
+			if !reflect.DeepEqual(got, tc.want) && !(len(got) == 0 && len(tc.want) == 0) {
+				t.Fatalf("DiffInterfaces(%v, %v, _) = %v, want %v",
+					tc.current, tc.baseline, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBaselineRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vpn_baseline.json")
+
+	if _, err := LoadBaseline(path); !errors.Is(err, ErrNoBaseline) {
+		t.Fatalf("expected ErrNoBaseline on missing file, got %v", err)
+	}
+
+	b, err := CaptureBaseline(path)
+	if err != nil {
+		t.Fatalf("CaptureBaseline failed: %v", err)
+	}
+	if len(b.Interfaces) == 0 {
+		t.Fatalf("expected at least one interface, got none")
+	}
+	if b.CapturedAt.IsZero() {
+		t.Fatalf("expected non-zero CapturedAt")
+	}
+
+	loaded, err := LoadBaseline(path)
+	if err != nil {
+		t.Fatalf("LoadBaseline failed: %v", err)
+	}
+	if !reflect.DeepEqual(loaded.Interfaces, b.Interfaces) {
+		t.Fatalf("interfaces mismatch after round-trip: got %v, want %v",
+			loaded.Interfaces, b.Interfaces)
+	}
+
+	if err := ResetBaseline(path); err != nil {
+		t.Fatalf("ResetBaseline failed: %v", err)
+	}
+	if _, err := LoadBaseline(path); !errors.Is(err, ErrNoBaseline) {
+		t.Fatalf("expected ErrNoBaseline after reset, got %v", err)
+	}
+
+	// Reset on missing file is a no-op (no error).
+	if err := ResetBaseline(path); err != nil {
+		t.Fatalf("ResetBaseline on missing file should be no-op, got %v", err)
+	}
+}
+
+func TestMatchAnyIgnoresBadPattern(t *testing.T) {
+	if matchAny("utun0", []string{`[`, `^utun`}) != true {
+		t.Fatalf("expected match on valid pattern despite bad sibling")
+	}
+	if matchAny("en0", []string{`[`}) != false {
+		t.Fatalf("expected no match when only pattern is invalid")
+	}
+}


### PR DESCRIPTION
The previous interface check (cfg.UndesiredInterfaces) regex-matched every interface against a static deny-list, which on macOS produced noisy false positives (gif0, stf0, every utun*) and trained users to hit "y" without reading. It also never distinguished baseline system state from a newly-attached customer VPN — the actual risk this feature exists to mitigate.

The new model:

* On first `connect`, prompt the user to confirm no customer VPN is active and snapshot the current interface set to a baseline JSON at ~/.ssh/cache/vpn_baseline.json. The baseline doubles as the trust list — anything in it is ignored on subsequent runs.
* On every subsequent `connect`, diff the current interfaces against the baseline, filter to VPN-like names (tun/utun/ppp/tap/wg/ipsec, overridable via SSH_MS_VPN_PATTERNS), and prompt only when the delta is non-empty.
* Both prompts explain the cross-customer routing risk and point at `ssh_ms vpn-baseline {capture, reset, show}` for state management. The delta prompt's recommended remediation is to re-capture the baseline while only the to-be-trusted VPN is connected.
* `--check-vpn=false` on the `connect` command bypasses the check entirely for one run.

Dropped: cfg.UndesiredInterfaces, SSH_MS_VPN_CHECK_NAMES build-time deny-list, SSH_MS_BYPASS_INTERFACE_CHECK env, and the buggy checkNetworkInterfaces logic (the inner !re.MatchString branch effectively blocked nothing under the originally-intended semantics).

config/versions.go is a side-effect of `go generate` catching up to the already-merged Vault SDK 0.25.0 / API 1.23.0 dependabot bumps.